### PR TITLE
Created remaining university endpoints

### DIFF
--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityAdder.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityAdder.java
@@ -13,7 +13,7 @@ public class UniversityAdder implements AddUniversity {
         this.universities = universities;
     }
 
-    public University addUniversity(String shortName, String fullName) {
+    public University add(String shortName, String fullName) {
         var university = new University(shortName, fullName);
         if (universities.findByShortNameAndFullName(shortName, fullName) != null) {
             throw new IllegalArgumentException("University already exists."); // TODO: handle this properly

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityAdder.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityAdder.java
@@ -15,7 +15,7 @@ public class UniversityAdder implements AddUniversity {
 
     public University addUniversity(String shortName, String fullName) {
         var university = new University(shortName, fullName);
-        if (universities.getByShortNameAndFullName(shortName, fullName) != null) {
+        if (universities.findByShortNameAndFullName(shortName, fullName) != null) {
             throw new IllegalArgumentException("University already exists."); // TODO: handle this properly
         }
         return universities.save(university);

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityDeleter.java
@@ -11,7 +11,7 @@ public class UniversityDeleter implements DeleteUniversity {
 
     private final Universities universities;
 
-    public  UniversityDeleter(Universities universities) {
+    public UniversityDeleter(Universities universities) {
         this.universities = universities;
     }
 

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityDeleter.java
@@ -1,0 +1,24 @@
+package com.mufidgu.pastpapers.domain.university;
+
+import com.mufidgu.pastpapers.domain.university.api.DeleteUniversity;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import ddd.DomainService;
+
+import java.util.UUID;
+
+@DomainService
+public class UniversityDeleter implements DeleteUniversity {
+
+    private final Universities universities;
+
+    public  UniversityDeleter(Universities universities) {
+        this.universities = universities;
+    }
+
+    public void delete(UUID id) {
+        if (universities.findById(id.toString()) == null) {
+            throw new IllegalArgumentException("University with id " + id + " does not exist.");
+        }
+        universities.delete(id);
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityDeleter.java
@@ -16,7 +16,7 @@ public class UniversityDeleter implements DeleteUniversity {
     }
 
     public void delete(UUID id) {
-        if (universities.findById(id.toString()) == null) {
+        if (universities.findById(id) == null) {
             throw new IllegalArgumentException("University with id " + id + " does not exist.");
         }
         universities.delete(id);

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityFetcher.java
@@ -15,7 +15,7 @@ public class UniversityFetcher implements FetchUniversities {
 
     private final Universities universities;
 
-    public List<University> fetchUniversities() {
+    public List<University> fetchAll() {
         return universities.getAll();
     }
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityUpdater.java
@@ -1,0 +1,34 @@
+package com.mufidgu.pastpapers.domain.university;
+
+import com.mufidgu.pastpapers.domain.university.api.UpdateUniversity;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import ddd.DomainService;
+
+import java.util.UUID;
+
+@DomainService
+public class UniversityUpdater implements UpdateUniversity {
+
+    private final Universities universities;
+
+    public UniversityUpdater(Universities universities) {
+        this.universities = universities;
+    }
+
+    public University updateUniversity(String idString, String shortName, String fullName) {
+        // TODO: better exception handling
+        if (universities.findById(idString) == null) {
+            throw new IllegalArgumentException("University not found with id: " + idString);
+        }
+        if (universities.findByShortNameAndFullName(shortName, fullName) != null) {
+            throw new IllegalArgumentException("University with the same short name and full name already exists");
+        }
+
+        // TODO: Revisit this when adding database to project
+        UUID id = UUID.fromString(idString);
+        University university = new University(id, shortName, fullName);
+        universities.save(university);
+
+        return university;
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityUpdater.java
@@ -15,17 +15,16 @@ public class UniversityUpdater implements UpdateUniversity {
         this.universities = universities;
     }
 
-    public University updateUniversity(String idString, String shortName, String fullName) {
+    public University update(UUID id, String shortName, String fullName) {
         // TODO: better exception handling
-        if (universities.findById(idString) == null) {
-            throw new IllegalArgumentException("University not found with id: " + idString);
+        if (universities.findById(id.toString()) == null) {
+            throw new IllegalArgumentException("University not found with id: " + id);
         }
         if (universities.findByShortNameAndFullName(shortName, fullName) != null) {
             throw new IllegalArgumentException("University with the same short name and full name already exists");
         }
 
         // TODO: Revisit this when adding database to project
-        UUID id = UUID.fromString(idString);
         University university = new University(id, shortName, fullName);
         universities.save(university);
 

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityUpdater.java
@@ -17,7 +17,7 @@ public class UniversityUpdater implements UpdateUniversity {
 
     public University update(UUID id, String shortName, String fullName) {
         // TODO: better exception handling
-        if (universities.findById(id.toString()) == null) {
+        if (universities.findById(id) == null) {
             throw new IllegalArgumentException("University not found with id: " + id);
         }
         if (universities.findByShortNameAndFullName(shortName, fullName) != null) {

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/api/AddUniversity.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/api/AddUniversity.java
@@ -3,5 +3,5 @@ package com.mufidgu.pastpapers.domain.university.api;
 import com.mufidgu.pastpapers.domain.university.University;
 
 public interface AddUniversity {
-    University addUniversity(String shortName, String fullName);
+    University add(String shortName, String fullName);
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/api/DeleteUniversity.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/api/DeleteUniversity.java
@@ -1,0 +1,7 @@
+package com.mufidgu.pastpapers.domain.university.api;
+
+import java.util.UUID;
+
+public interface DeleteUniversity {
+    void delete(UUID id);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/api/FetchUniversities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/api/FetchUniversities.java
@@ -5,5 +5,5 @@ import com.mufidgu.pastpapers.domain.university.University;
 import java.util.List;
 
 public interface FetchUniversities {
-    List<University> fetchUniversities();
+    List<University> fetchAll();
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/api/UpdateUniversity.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/api/UpdateUniversity.java
@@ -2,6 +2,8 @@ package com.mufidgu.pastpapers.domain.university.api;
 
 import com.mufidgu.pastpapers.domain.university.University;
 
+import java.util.UUID;
+
 public interface UpdateUniversity {
-    University updateUniversity(String id, String shortName, String fullName);
+    University update(UUID id, String shortName, String fullName);
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/api/UpdateUniversity.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/api/UpdateUniversity.java
@@ -1,0 +1,7 @@
+package com.mufidgu.pastpapers.domain.university.api;
+
+import com.mufidgu.pastpapers.domain.university.University;
+
+public interface UpdateUniversity {
+    University updateUniversity(String id, String shortName, String fullName);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/spi/Universities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/spi/Universities.java
@@ -9,6 +9,6 @@ public interface Universities {
     University save(University university);
     University findByShortNameAndFullName(String shortName, String fullName);
     List<University> getAll();
-    University findById(String id);
+    University findById(UUID id);
     void delete(UUID id);
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/spi/Universities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/spi/Universities.java
@@ -3,10 +3,12 @@ package com.mufidgu.pastpapers.domain.university.spi;
 import com.mufidgu.pastpapers.domain.university.University;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface Universities {
     University save(University university);
     University findByShortNameAndFullName(String shortName, String fullName);
     List<University> getAll();
     University findById(String id);
+    void delete(UUID id);
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/spi/Universities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/spi/Universities.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public interface Universities {
     University save(University university);
-    University getByShortNameAndFullName(String shortName, String fullName);
+    University findByShortNameAndFullName(String shortName, String fullName);
     List<University> getAll();
+    University findById(String id);
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/spi/stubs/InMemoryUniversities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/spi/stubs/InMemoryUniversities.java
@@ -35,4 +35,8 @@ public class InMemoryUniversities implements Universities {
                 .findFirst()
                 .orElse(null);
     }
+
+    public void delete(UUID id) {
+        universities.remove(id);
+    }
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/spi/stubs/InMemoryUniversities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/spi/stubs/InMemoryUniversities.java
@@ -18,7 +18,7 @@ public class InMemoryUniversities implements Universities {
         return university;
     }
 
-    public University getByShortNameAndFullName(String shortName, String fullName) {
+    public University findByShortNameAndFullName(String shortName, String fullName) {
         return universities.values().stream()
                 .filter(u -> u.shortName().equals(shortName) && u.fullName().equals(fullName))
                 .findFirst()
@@ -27,5 +27,12 @@ public class InMemoryUniversities implements Universities {
 
     public List<University> getAll() {
         return List.copyOf(universities.values());
+    }
+
+    public University findById(String id) {
+        return universities.values().stream()
+                .filter(u -> u.id().toString().equals(id))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/spi/stubs/InMemoryUniversities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/spi/stubs/InMemoryUniversities.java
@@ -29,11 +29,8 @@ public class InMemoryUniversities implements Universities {
         return List.copyOf(universities.values());
     }
 
-    public University findById(String id) {
-        return universities.values().stream()
-                .filter(u -> u.id().toString().equals(id))
-                .findFirst()
-                .orElse(null);
+    public University findById(UUID id) {
+        return universities.get(id);
     }
 
     public void delete(UUID id) {

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityController.java
@@ -1,7 +1,7 @@
 package com.mufidgu.pastpapers.infrastructure.controller.university;
 
-import com.mufidgu.pastpapers.domain.university.UniversityDeleter;
 import com.mufidgu.pastpapers.domain.university.api.AddUniversity;
+import com.mufidgu.pastpapers.domain.university.api.DeleteUniversity;
 import com.mufidgu.pastpapers.domain.university.api.FetchUniversities;
 import com.mufidgu.pastpapers.domain.university.api.UpdateUniversity;
 import jakarta.validation.Valid;
@@ -21,13 +21,13 @@ public class UniversityController {
     private final AddUniversity universityAdder;
     private final FetchUniversities universityFetcher;
     private final UpdateUniversity universityUpdater;
-    private final UniversityDeleter universityDeleter;
+    private final DeleteUniversity universityDeleter;
 
     public UniversityController(
             AddUniversity universityAdder,
             FetchUniversities universityFetcher,
             UpdateUniversity universityUpdater,
-            UniversityDeleter universityDeleter) {
+            DeleteUniversity universityDeleter) {
         this.universityAdder = universityAdder;
         this.universityFetcher = universityFetcher;
         this.universityUpdater = universityUpdater;

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityController.java
@@ -1,13 +1,17 @@
 package com.mufidgu.pastpapers.infrastructure.controller.university;
 
+import com.mufidgu.pastpapers.domain.university.UniversityDeleter;
 import com.mufidgu.pastpapers.domain.university.api.AddUniversity;
 import com.mufidgu.pastpapers.domain.university.api.FetchUniversities;
 import com.mufidgu.pastpapers.domain.university.api.UpdateUniversity;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @Validated
 @RestController
@@ -17,22 +21,24 @@ public class UniversityController {
     private final AddUniversity universityAdder;
     private final FetchUniversities universityFetcher;
     private final UpdateUniversity universityUpdater;
+    private final UniversityDeleter universityDeleter;
 
     public UniversityController(
             AddUniversity universityAdder,
             FetchUniversities universityFetcher,
-            UpdateUniversity universityUpdater
-    ) {
+            UpdateUniversity universityUpdater,
+            UniversityDeleter universityDeleter) {
         this.universityAdder = universityAdder;
         this.universityFetcher = universityFetcher;
         this.universityUpdater = universityUpdater;
+        this.universityDeleter = universityDeleter;
     }
 
     // TODO: Admin Only
     // Test Cases: Validation, Duplicate Short Name and Full Name,
     @PostMapping("/add")
     public ResponseEntity<UniversityResource> addUniversity(@Valid @RequestBody UniversityRequest request) {
-        var university = universityAdder.addUniversity(request.shortName, request.fullName);
+        var university = universityAdder.add(request.shortName, request.fullName);
         return ResponseEntity.ok(new UniversityResource(
                 university.id(),
                 university.shortName(),
@@ -43,7 +49,7 @@ public class UniversityController {
     // TODO: Registered Users Only
     @GetMapping("/all")
     public ResponseEntity<Iterable<UniversityResource>> getAllUniversities() {
-        var universities = universityFetcher.fetchUniversities();
+        var universities = universityFetcher.fetchAll();
         return ResponseEntity.ok(universities.stream()
                 .map(u -> new UniversityResource(u.id(), u.shortName(), u.fullName()))
                 .toList());
@@ -56,11 +62,21 @@ public class UniversityController {
             @RequestParam @NotBlank String universityId,
             @Valid @RequestBody UniversityRequest request
     ) {
-        var university = universityUpdater.updateUniversity(universityId, request.shortName, request.fullName);
+        var id = UUID.fromString(universityId);
+        var university = universityUpdater.update(id, request.shortName, request.fullName);
         return ResponseEntity.ok(new UniversityResource(
                 university.id(),
                 university.shortName(),
                 university.fullName()
         ));
+    }
+
+    // TODO: Admin Only
+    // Test Cases: Validation, University Not Found
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> deleteUniversity(@RequestParam @NotBlank String universityId) {
+        var id = UUID.fromString(universityId);
+        universityDeleter.delete(id);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityController.java
@@ -2,25 +2,36 @@ package com.mufidgu.pastpapers.infrastructure.controller.university;
 
 import com.mufidgu.pastpapers.domain.university.api.AddUniversity;
 import com.mufidgu.pastpapers.domain.university.api.FetchUniversities;
+import com.mufidgu.pastpapers.domain.university.api.UpdateUniversity;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Validated
 @RestController
 @RequestMapping("/university")
 public class UniversityController {
 
     private final AddUniversity universityAdder;
     private final FetchUniversities universityFetcher;
+    private final UpdateUniversity universityUpdater;
 
-    public UniversityController(AddUniversity universityAdder, FetchUniversities universityFetcher) {
+    public UniversityController(
+            AddUniversity universityAdder,
+            FetchUniversities universityFetcher,
+            UpdateUniversity universityUpdater
+    ) {
         this.universityAdder = universityAdder;
         this.universityFetcher = universityFetcher;
+        this.universityUpdater = universityUpdater;
     }
 
     // TODO: Admin Only
-    // Test Cases: Validation, Duplicate Short Name, Duplicate Full Name,
+    // Test Cases: Validation, Duplicate Short Name and Full Name,
     @PostMapping("/add")
-    public ResponseEntity<UniversityResource> addUniversity(@RequestBody AddUniversityRequest request) {
+    public ResponseEntity<UniversityResource> addUniversity(@Valid @RequestBody UniversityRequest request) {
         var university = universityAdder.addUniversity(request.shortName, request.fullName);
         return ResponseEntity.ok(new UniversityResource(
                 university.id(),
@@ -36,5 +47,20 @@ public class UniversityController {
         return ResponseEntity.ok(universities.stream()
                 .map(u -> new UniversityResource(u.id(), u.shortName(), u.fullName()))
                 .toList());
+    }
+
+    // TODO: Admin Only
+    // Test Cases: Validation, Duplicate Short Name and Full Name,
+    @PutMapping("/update")
+    public ResponseEntity<UniversityResource> updateUniversity(
+            @RequestParam @NotBlank String universityId,
+            @Valid @RequestBody UniversityRequest request
+    ) {
+        var university = universityUpdater.updateUniversity(universityId, request.shortName, request.fullName);
+        return ResponseEntity.ok(new UniversityResource(
+                university.id(),
+                university.shortName(),
+                university.fullName()
+        ));
     }
 }

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityRequest.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityRequest.java
@@ -3,7 +3,7 @@ package com.mufidgu.pastpapers.infrastructure.controller.university;
 import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.Length;
 
-public class AddUniversityRequest {
+public class UniversityRequest {
     @NotBlank
     @Length(min = 3, max = 30)
     public String shortName;

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityControllerTest.java
@@ -87,7 +87,6 @@ public class UniversityControllerTest {
 
         mockMvc.perform(
                 delete("/university/delete?universityId=" + university.id())
-                        .contentType("application/json")
         )
                 .andExpect(status().isOk());
 

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityControllerTest.java
@@ -14,9 +14,7 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -60,6 +58,26 @@ public class UniversityControllerTest {
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$").isNotEmpty())
                 .andExpect(jsonPath("$[?(@.shortName == 'Stanford')]").exists());
+    }
+
+    @Test
+    void should_update_university() throws Exception {
+        University university = universities.save(new University("Harvard", "Harvard University"));
+
+        mockMvc.perform(
+                put("/university/update?universityId=" + university.id())
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                    "shortName": "Harvard Updated",
+                                    "fullName": "Harvard University Updated"
+                                }
+                                """)
+        )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(university.id().toString()))
+                .andExpect(jsonPath("$.shortName").value("Harvard Updated"))
+                .andExpect(jsonPath("$.fullName").value("Harvard University Updated"));
     }
 
     @TestConfiguration

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityControllerTest.java
@@ -80,6 +80,23 @@ public class UniversityControllerTest {
                 .andExpect(jsonPath("$.fullName").value("Harvard University Updated"));
     }
 
+
+    @Test
+    void should_delete_university() throws Exception {
+        University university = universities.save(new University("Yale", "Yale University"));
+
+        mockMvc.perform(
+                delete("/university/delete?universityId=" + university.id())
+                        .contentType("application/json")
+        )
+                .andExpect(status().isOk());
+
+        // Verify that the university is deleted
+        mockMvc.perform(get("/university/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.shortName == 'Yale')]").doesNotExist());
+    }
+
     @TestConfiguration
     @ComponentScan(
             basePackageClasses = {University.class},


### PR DESCRIPTION
This pull request introduces update and delete functionality for universities, refactors existing add and fetch operations for consistency, and improves API and domain service structure. It also updates the controller and test suite to support these new operations, and renames request classes for clarity.

**API and Domain Service Enhancements:**

* Added `UpdateUniversity` and `DeleteUniversity` interfaces and their implementations (`UniversityUpdater`, `UniversityDeleter`) to support updating and deleting universities.
* Updated the `Universities` SPI and its in-memory stub to include `findById`, `findByShortNameAndFullName`, and `delete` methods, replacing `getByShortNameAndFullName` for naming consistency.

**Controller and Request Refactoring:**

* Updated `UniversityController` to support add, fetch, update, and delete endpoints, and refactored to use new service interfaces and request class.
* Renamed `AddUniversityRequest` to `UniversityRequest` for reuse in both add and update operations.

**API Naming Consistency:**

* Renamed methods in API interfaces and implementations for consistency: `addUniversity` → `add`, `fetchUniversities` → `fetchAll`, and `getByShortNameAndFullName` → `findByShortNameAndFullName`.

**Testing:**

* Added integration tests for update and delete endpoints in `UniversityControllerTest`, ensuring correct behavior for these new features.

**Miscellaneous:**

* Updated imports and request mappings in the controller and test files to align with new functionality and naming conventions.