### PR TITLE
11 create all endpoints for degree

### DIFF
--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/Degree.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/Degree.java
@@ -1,0 +1,10 @@
+package com.mufidgu.pastpapers.domain.degree;
+
+import java.util.List;
+import java.util.UUID;
+
+public record Degree(UUID id, String shortName, String fullName, List<UUID> universities) {
+    public Degree(String shortName, String fullName, List<UUID> universities) {
+        this(UUID.randomUUID(), shortName, fullName, universities);
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeAdder.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeAdder.java
@@ -1,0 +1,12 @@
+package com.mufidgu.pastpapers.domain.degree;
+
+import com.mufidgu.pastpapers.domain.degree.api.AddDegree;
+
+import java.util.List;
+import java.util.UUID;
+
+public class DegreeAdder implements AddDegree {
+    public Degree addDegree(String shortName, String fullName, List<UUID> universities) {
+        return null;
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeDeleter.java
@@ -1,0 +1,25 @@
+package com.mufidgu.pastpapers.domain.degree;
+
+import com.mufidgu.pastpapers.domain.degree.api.DeleteDegree;
+import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
+import ddd.DomainService;
+
+import java.util.UUID;
+
+@DomainService
+public class DegreeDeleter implements DeleteDegree {
+
+    private final Degrees degrees;
+
+    public DegreeDeleter(Degrees degrees) {
+        this.degrees = degrees;
+    }
+
+    public void delete(UUID id) {
+        // TODO: better exception handling
+        degrees.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Degree does not exist"));
+
+        degrees.delete(id);
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeFetcher.java
@@ -1,0 +1,21 @@
+package com.mufidgu.pastpapers.domain.degree;
+
+import com.mufidgu.pastpapers.domain.degree.api.FetchDegree;
+import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
+import ddd.DomainService;
+
+import java.util.List;
+
+@DomainService
+public class DegreeFetcher implements FetchDegree {
+
+    private final Degrees degrees;
+
+    public DegreeFetcher(Degrees degrees) {
+        this.degrees = degrees;
+    }
+
+    public List<Degree> fetchAll() {
+        return degrees.findAll();
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeUpdater.java
@@ -1,6 +1,6 @@
 package com.mufidgu.pastpapers.domain.degree;
 
-import com.mufidgu.pastpapers.domain.degree.api.AddDegree;
+import com.mufidgu.pastpapers.domain.degree.api.UpdateDegree;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
@@ -9,18 +9,19 @@ import java.util.List;
 import java.util.UUID;
 
 @DomainService
-public class DegreeAdder implements AddDegree {
+public class DegreeUpdater implements UpdateDegree {
 
     private final Degrees degrees;
     private final Universities universities;
 
-    public DegreeAdder(Degrees degrees, Universities universities) {
+    public DegreeUpdater(Degrees degrees, Universities universities) {
         this.degrees = degrees;
         this.universities = universities;
     }
 
-    public Degree add(String shortName, String fullName, List<UUID> universities) {
+    public Degree update(UUID id, String shortName, String fullName, List<UUID> universities) {
         // TODO: better exception handling
+        Degree degree = degrees.findById(id).orElseThrow(() -> new IllegalArgumentException("Degree does not exist"));
         degrees.findByShortNameAndFullName(shortName, fullName).ifPresent(d -> {
             throw new IllegalArgumentException("Degree with the same short name and full name already exists");
         });
@@ -30,7 +31,8 @@ public class DegreeAdder implements AddDegree {
             }
         });
 
-        Degree degree = new Degree(shortName, fullName, universities);
-        return degrees.save(degree);
+        return degrees.save(
+                new Degree(degree.id(), shortName, fullName, universities)
+        );
     }
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/api/AddDegree.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/api/AddDegree.java
@@ -1,0 +1,10 @@
+package com.mufidgu.pastpapers.domain.degree.api;
+
+import com.mufidgu.pastpapers.domain.degree.Degree;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AddDegree {
+    Degree addDegree(String shortName, String fullName, List<UUID> universities);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/api/DeleteDegree.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/api/DeleteDegree.java
@@ -1,0 +1,7 @@
+package com.mufidgu.pastpapers.domain.degree.api;
+
+import java.util.UUID;
+
+public interface DeleteDegree {
+    void delete(UUID id);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/api/FetchDegree.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/api/FetchDegree.java
@@ -3,8 +3,7 @@ package com.mufidgu.pastpapers.domain.degree.api;
 import com.mufidgu.pastpapers.domain.degree.Degree;
 
 import java.util.List;
-import java.util.UUID;
 
-public interface AddDegree {
-    Degree add(String shortName, String fullName, List<UUID> universities);
+public interface FetchDegree {
+    List<Degree> fetchAll();
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/api/UpdateDegree.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/api/UpdateDegree.java
@@ -5,6 +5,6 @@ import com.mufidgu.pastpapers.domain.degree.Degree;
 import java.util.List;
 import java.util.UUID;
 
-public interface AddDegree {
-    Degree add(String shortName, String fullName, List<UUID> universities);
+public interface UpdateDegree {
+    Degree update(UUID id, String shortName, String fullName, List<UUID> universities);
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/Degrees.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/Degrees.java
@@ -2,8 +2,14 @@ package com.mufidgu.pastpapers.domain.degree.spi;
 
 import com.mufidgu.pastpapers.domain.degree.Degree;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface Degrees {
-    Optional<Degree> addDegree(Degree degree);
+    Degree save(Degree degree);
+    Optional<Degree> findByShortNameAndFullName(String shortName, String fullName);
+    Optional<Degree> findById(UUID id);
+    void delete(UUID id);
+    List<Degree> findAll();
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/Degrees.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/Degrees.java
@@ -1,0 +1,9 @@
+package com.mufidgu.pastpapers.domain.degree.spi;
+
+import com.mufidgu.pastpapers.domain.degree.Degree;
+
+import java.util.Optional;
+
+public interface Degrees {
+    Optional<Degree> addDegree(Degree degree);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/stubs/InMemoryDegrees.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/stubs/InMemoryDegrees.java
@@ -2,9 +2,11 @@ package com.mufidgu.pastpapers.domain.degree.spi.stubs;
 
 import com.mufidgu.pastpapers.domain.degree.Degree;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
+import ddd.Stub;
 
 import java.util.*;
 
+@Stub
 public class InMemoryDegrees implements Degrees {
 
     HashMap<UUID, Degree> degrees = new HashMap<>();

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/stubs/InMemoryDegrees.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/stubs/InMemoryDegrees.java
@@ -1,0 +1,35 @@
+package com.mufidgu.pastpapers.domain.degree.spi.stubs;
+
+import com.mufidgu.pastpapers.domain.degree.Degree;
+import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
+
+import java.util.*;
+
+public class InMemoryDegrees implements Degrees {
+
+    HashMap<UUID, Degree> degrees = new HashMap<>();
+
+    public Degree save(Degree degree) {
+        degrees.put(degree.id(), degree);
+        return degree;
+    }
+
+    public Optional<Degree> findByShortNameAndFullName(String shortName, String fullName) {
+        return degrees.values().stream()
+                .filter(degree -> degree.shortName().equals(shortName) && degree.fullName().equals(fullName))
+                .findFirst();
+    }
+
+    public Optional<Degree> findById(UUID id) {
+        return Optional.ofNullable(degrees.get(id));
+    }
+
+    public void delete(UUID id) {
+        degrees.remove(id);
+    }
+
+    public List<Degree> findAll() {
+        return new ArrayList<>(degrees.values());
+    }
+
+}

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeController.java
@@ -40,10 +40,7 @@ public class DegreeController {
     // Test cases validation, Already Exists, University Does Not Exist
     @PostMapping("/add")
     public ResponseEntity<DegreeResource> addDegree(@Valid @RequestBody DegreeRequest request) {
-        List<UUID> universities = request.universityIds.stream()
-                .map(UUID::fromString)
-                .toList();
-        Degree degree = degreeAdder.add(request.shortName, request.fullName, universities);
+        Degree degree = degreeAdder.add(request.shortName, request.fullName, request.universityIds);
         return ResponseEntity.ok(new DegreeResource(
                 degree.id(),
                 degree.shortName(),
@@ -56,18 +53,15 @@ public class DegreeController {
     // Test cases validation, Degree/University Does Not Exist
     @PostMapping("/update")
     public ResponseEntity<DegreeResource> updateDegree(
-            @NotBlank String degreeId,
+            @RequestParam @NotBlank String degreeId,
             @Valid @RequestBody DegreeRequest request
     ) {
-        List<UUID> universities = request.universityIds.stream()
-                .map(UUID::fromString)
-                .toList();
         UUID id = UUID.fromString(degreeId);
         Degree degree = degreeUpdater.update(
                 id,
                 request.shortName,
                 request.fullName,
-                universities
+                request.universityIds
         );
         return ResponseEntity.ok(new DegreeResource(
                 degree.id(),
@@ -80,7 +74,7 @@ public class DegreeController {
     // TODO: Admin only
     // Test cases validation, Degree Does Not Exist
     @PostMapping("/delete")
-    public ResponseEntity<Void> deleteDegree(@NotBlank String degreeId) {
+    public ResponseEntity<Void> deleteDegree(@RequestParam @NotBlank String degreeId) {
         UUID id = UUID.fromString(degreeId);
         degreeDeleter.delete(id);
         return ResponseEntity.status(HttpStatus.OK).build();

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeController.java
@@ -1,0 +1,97 @@
+package com.mufidgu.pastpapers.infrastructure.controller.degree;
+
+import com.mufidgu.pastpapers.domain.degree.Degree;
+import com.mufidgu.pastpapers.domain.degree.api.AddDegree;
+import com.mufidgu.pastpapers.domain.degree.api.DeleteDegree;
+import com.mufidgu.pastpapers.domain.degree.api.FetchDegree;
+import com.mufidgu.pastpapers.domain.degree.api.UpdateDegree;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Validated
+@RestController
+@RequestMapping("/degree")
+public class DegreeController {
+
+    private final AddDegree degreeAdder;
+    private final FetchDegree degreeFetcher;
+    private final UpdateDegree degreeUpdater;
+    private final DeleteDegree degreeDeleter;
+
+    public DegreeController(
+            AddDegree degreeAdder,
+            FetchDegree degreeFetcher,
+            UpdateDegree degreeUpdater,
+            DeleteDegree degreeDeleter) {
+        this.degreeAdder = degreeAdder;
+        this.degreeFetcher = degreeFetcher;
+        this.degreeUpdater = degreeUpdater;
+        this.degreeDeleter = degreeDeleter;
+    }
+
+    // TODO: Admin only
+    // Test cases validation, Already Exists, University Does Not Exist
+    @PostMapping("/add")
+    public ResponseEntity<DegreeResource> addDegree(@Valid @RequestBody DegreeRequest request) {
+        List<UUID> universities = request.universityIds.stream()
+                .map(UUID::fromString)
+                .toList();
+        Degree degree = degreeAdder.add(request.shortName, request.fullName, universities);
+        return ResponseEntity.ok(new DegreeResource(
+                degree.id(),
+                degree.shortName(),
+                degree.fullName(),
+                degree.universities()
+        ));
+    }
+
+    // TODO: Admin only
+    // Test cases validation, Degree/University Does Not Exist
+    @PostMapping("/update")
+    public ResponseEntity<DegreeResource> updateDegree(
+            @NotBlank String degreeId,
+            @Valid @RequestBody DegreeRequest request
+    ) {
+        List<UUID> universities = request.universityIds.stream()
+                .map(UUID::fromString)
+                .toList();
+        UUID id = UUID.fromString(degreeId);
+        Degree degree = degreeUpdater.update(
+                id,
+                request.shortName,
+                request.fullName,
+                universities
+        );
+        return ResponseEntity.ok(new DegreeResource(
+                degree.id(),
+                degree.shortName(),
+                degree.fullName(),
+                degree.universities()
+        ));
+    }
+
+    // TODO: Admin only
+    // Test cases validation, Degree Does Not Exist
+    @PostMapping("/delete")
+    public ResponseEntity<Void> deleteDegree(@NotBlank String degreeId) {
+        UUID id = UUID.fromString(degreeId);
+        degreeDeleter.delete(id);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    // TODO: Registered users only
+    @GetMapping("/all")
+    public ResponseEntity<Iterable<DegreeResource>> getAllDegrees() {
+        var degrees = degreeFetcher.fetchAll();
+        return ResponseEntity.ok(degrees.stream()
+                .map(d -> new DegreeResource(d.id(), d.shortName(), d.fullName(), d.universities()))
+                .toList());
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeRequest.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeRequest.java
@@ -15,5 +15,5 @@ public class DegreeRequest {
     @Length(min = 3, max = 100)
     public String fullName;
 
-    public List<String> universityIds;
+    public List<UUID> universityIds;
 }

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeRequest.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeRequest.java
@@ -1,0 +1,19 @@
+package com.mufidgu.pastpapers.infrastructure.controller.degree;
+
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
+import java.util.UUID;
+
+public class DegreeRequest {
+    @NotBlank
+    @Length(min = 2, max = 30)
+    public String shortName;
+
+    @NotBlank
+    @Length(min = 3, max = 100)
+    public String fullName;
+
+    public List<String> universityIds;
+}

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeResource.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeResource.java
@@ -1,0 +1,7 @@
+package com.mufidgu.pastpapers.infrastructure.controller.degree;
+
+import java.util.List;
+import java.util.UUID;
+
+public record DegreeResource(UUID id, String shortName, String fullName, List<UUID> universities) {
+}

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeControllerTest.java
@@ -1,0 +1,130 @@
+package com.mufidgu.pastpapers.infrastructure.controller.degree;
+
+import com.mufidgu.pastpapers.domain.degree.Degree;
+import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
+import com.mufidgu.pastpapers.domain.university.University;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import com.mufidgu.pastpapers.infrastructure.configuration.DomainConfiguration;
+import ddd.Stub;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+@Import(DomainConfiguration.class)
+public class DegreeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private Degrees degrees;
+
+    @Autowired
+    private Universities universities;
+
+    private University testUniversity;
+    private University secondTestUniversity;
+
+    @BeforeEach
+    void setUp() {
+        // Create test universities to use in degree tests
+        testUniversity = universities.save(new University("MIT", "Massachusetts Institute of Technology"));
+        secondTestUniversity = universities.save(new University("Stanford", "Stanford University"));
+    }
+
+    @Test
+    void should_add_degree() throws Exception {
+        mockMvc.perform(
+                post("/degree/add")
+                        .contentType("application/json")
+                        .content(String.format("""
+                                {
+                                    "shortName": "CS",
+                                    "fullName": "Computer Science",
+                                    "universityIds": ["%s"]
+                                }
+                                """, testUniversity.id()))
+        )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andExpect(jsonPath("$.shortName").value("CS"))
+                .andExpect(jsonPath("$.fullName").value("Computer Science"))
+                .andExpect(jsonPath("$.universities[0]").value(testUniversity.id().toString()));
+    }
+
+    @Test
+    void should_return_all_degrees() throws Exception {
+        // Create a test degree
+        degrees.save(new Degree("Math", "Mathematics", List.of(testUniversity.id())));
+
+        mockMvc.perform(
+                get("/degree/all")
+                        .contentType("application/json")
+        )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isNotEmpty())
+                .andExpect(jsonPath("$[?(@.shortName == 'Math')]").exists());
+    }
+
+    @Test
+    void should_update_degree() throws Exception {
+        // Create a test degree
+        Degree degree = degrees.save(new Degree("Phys", "Physics", List.of(testUniversity.id())));
+
+        mockMvc.perform(
+                post("/degree/update?degreeId=" + degree.id())
+                        .contentType("application/json")
+                        .content(String.format("""
+                                {
+                                    "shortName": "Physics",
+                                    "fullName": "Physics and Astronomy",
+                                    "universityIds": ["%s", "%s"]
+                                }
+                                """, testUniversity.id(), secondTestUniversity.id()))
+        )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(degree.id().toString()))
+                .andExpect(jsonPath("$.shortName").value("Physics"))
+                .andExpect(jsonPath("$.fullName").value("Physics and Astronomy"))
+                .andExpect(jsonPath("$.universities.length()").value(2));
+    }
+
+    @Test
+    void should_delete_degree() throws Exception {
+        // Create a test degree
+        Degree degree = degrees.save(new Degree("Bio", "Biology", List.of(testUniversity.id())));
+
+        mockMvc.perform(
+                post("/degree/delete?degreeId=" + degree.id())
+        )
+                .andExpect(status().isOk());
+
+        // Verify that the degree is deleted
+        mockMvc.perform(get("/degree/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.shortName == 'Bio')]").doesNotExist());
+    }
+
+    @TestConfiguration
+    @ComponentScan(
+            basePackageClasses = {Degree.class, University.class},
+            includeFilters = {@ComponentScan.Filter(type = FilterType.ANNOTATION, classes = {Stub.class})})
+    static class StubConfiguration {
+    }
+}
+


### PR DESCRIPTION
This pull request introduces a complete implementation of the Degree domain, including its core model, service layer, API contracts, persistence SPI (with an in-memory stub), REST controller, request/response models, and a comprehensive set of controller tests. The changes enable full CRUD (Create, Read, Update, Delete) operations for degrees, with validation and integration with universities.

Key changes include:

**Domain Model & Service Layer:**

* Introduced the `Degree` record as the main domain model, along with service classes for adding, updating, deleting, and fetching degrees (`DegreeAdder`, `DegreeUpdater`, `DegreeDeleter`, `DegreeFetcher`). These services handle validation, uniqueness checks, and integration with the university domain.

**API Contracts & Persistence SPI:**

* Added API interfaces for degree operations (`AddDegree`, `UpdateDegree`, `DeleteDegree`, `FetchDegree`) and a persistence SPI (`Degrees`) to abstract storage. Provided an in-memory implementation for testing and development.

**Web Layer (Controller & DTOs):**

* Implemented `DegreeController` with endpoints for adding, updating, deleting, and listing degrees. Added request and response DTOs (`DegreeRequest`, `DegreeResource`) with validation annotations.

**Testing:**

* Added `DegreeControllerTest` with tests covering all controller endpoints, including validation of CRUD operations and integration with the university domain.