### PR TITLE
ci: add CI workflow to run tests on pull requests

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -3,8 +3,6 @@ name: Build and Deploy
 on:
   push:
     branches: [ main, dev ]
-  pull_request:
-    branches: [ main, dev ]
 
 permissions:
   contents: read
@@ -21,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -39,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -3,6 +3,8 @@ name: Build and Deploy
 on:
   push:
     branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
 
 permissions:
   contents: read
@@ -13,7 +15,25 @@ env:
   DEV_PORT: 8444
 
 jobs:
+  run-tests:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Run Tests
+        run: ./gradlew test
+
   build-jar:
+    needs: run-tests
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,22 @@
+name: Run Tests
+on:
+  pull_request:
+    branches: [ main, dev ]
+
+jobs:
+  run-tests:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Run Tests
+        run: ./gradlew test


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to enhance the CI/CD process by ensuring tests are run automatically on both pushes and pull requests, and by enforcing that the build step only runs if tests pass. The main changes revolve around improving workflow safety and automation.

**Workflow automation and safety:**

* Added the `pull_request` trigger to the workflow so that CI runs on both pushes and pull requests targeting `main` and `dev` branches.
* Introduced a new `run-tests` job that checks out the code, sets up Java 21, ensures `gradlew` is executable, and runs the test suite.
* Updated the `build-jar` job to depend on the `run-tests` job, ensuring that builds only proceed if all tests pass.