### PR TITLE
15 add all course related endpoints

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +25,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/Course.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/Course.java
@@ -1,0 +1,16 @@
+package com.mufidgu.pastpapers.domain.course;
+
+import java.util.List;
+import java.util.UUID;
+
+public record Course(
+        UUID id,
+        String shortName,
+        String fullName,
+        List<UUID> degreeIds,
+        List<UUID> universityIds
+) {
+    public Course(String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds) {
+        this(UUID.randomUUID(), shortName, fullName, degreeIds, universityIds);
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseAdder.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseAdder.java
@@ -22,7 +22,7 @@ public class CourseAdder implements AddCourse {
         this.universities = universities;
     }
 
-    public Course addCourse(String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds) {
+    public Course add(String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds) {
         // TODO: better error handling
         courses.findByShortNameAndFullName(shortName, fullName)
                 .ifPresent(course -> {

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseAdder.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseAdder.java
@@ -1,0 +1,39 @@
+package com.mufidgu.pastpapers.domain.course;
+
+import com.mufidgu.pastpapers.domain.course.api.AddCourse;
+import com.mufidgu.pastpapers.domain.course.spi.Courses;
+import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import ddd.DomainService;
+
+import java.util.List;
+import java.util.UUID;
+
+@DomainService
+public class CourseAdder implements AddCourse {
+
+    private final Courses courses;
+    private final Degrees degrees;
+    private final Universities universities;
+
+    public CourseAdder(Courses courses, Degrees degrees, Universities universities) {
+        this.courses = courses;
+        this.degrees = degrees;
+        this.universities = universities;
+    }
+
+    public Course addCourse(String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds) {
+        // TODO: better error handling
+        courses.findByShortNameAndFullName(shortName, fullName)
+                .ifPresent(course -> {
+                    throw new IllegalArgumentException("Course with the same short name and full name already exists");
+                });
+        degreeIds.forEach(id -> degrees.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Degree with ID " + id + " does not exist")));
+        universityIds.forEach(id -> universities.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("University with ID " + id + " does not exist")));
+
+        Course course = new Course(shortName, fullName, degreeIds, universityIds);
+        return courses.save(course);
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseDeleter.java
@@ -1,0 +1,24 @@
+package com.mufidgu.pastpapers.domain.course;
+
+import com.mufidgu.pastpapers.domain.course.api.DeleteCourse;
+import com.mufidgu.pastpapers.domain.course.spi.Courses;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import ddd.DomainService;
+
+import java.util.UUID;
+
+@DomainService
+public class CourseDeleter implements DeleteCourse {
+
+    private final Courses courses;
+
+    public CourseDeleter(Courses courses) {
+        this.courses = courses;
+    }
+
+    public void delete(UUID courseId) {
+        courses.findById(courseId)
+            .orElseThrow(() -> new IllegalArgumentException("Course with ID " + courseId + " does not exist"));
+        courses.delete(courseId);
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseDeleter.java
@@ -2,7 +2,6 @@ package com.mufidgu.pastpapers.domain.course;
 
 import com.mufidgu.pastpapers.domain.course.api.DeleteCourse;
 import com.mufidgu.pastpapers.domain.course.spi.Courses;
-import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
 
 import java.util.UUID;
@@ -18,7 +17,7 @@ public class CourseDeleter implements DeleteCourse {
 
     public void delete(UUID courseId) {
         courses.findById(courseId)
-            .orElseThrow(() -> new IllegalArgumentException("Course with ID " + courseId + " does not exist"));
+                .orElseThrow(() -> new IllegalArgumentException("Course with ID " + courseId + " does not exist"));
         courses.delete(courseId);
     }
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseFetcher.java
@@ -2,7 +2,6 @@ package com.mufidgu.pastpapers.domain.course;
 
 import com.mufidgu.pastpapers.domain.course.api.FetchCourse;
 import com.mufidgu.pastpapers.domain.course.spi.Courses;
-import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
 
 import java.util.List;

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseFetcher.java
@@ -1,0 +1,22 @@
+package com.mufidgu.pastpapers.domain.course;
+
+import com.mufidgu.pastpapers.domain.course.api.FetchCourse;
+import com.mufidgu.pastpapers.domain.course.spi.Courses;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import ddd.DomainService;
+
+import java.util.List;
+
+@DomainService
+public class CourseFetcher implements FetchCourse {
+
+    private final Courses courses;
+
+    public CourseFetcher(Courses courses) {
+        this.courses = courses;
+    }
+
+    public List<Course> fetchAll() {
+        return courses.findAll();
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseUpdater.java
@@ -2,6 +2,7 @@ package com.mufidgu.pastpapers.domain.course;
 
 import com.mufidgu.pastpapers.domain.course.api.UpdateCourse;
 import com.mufidgu.pastpapers.domain.course.spi.Courses;
+import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
 
@@ -12,10 +13,12 @@ import java.util.UUID;
 public class CourseUpdater implements UpdateCourse {
 
     private final Courses courses;
+    private final Degrees degrees;
     private final Universities universities;
 
-    public CourseUpdater(Courses courses, Universities universities) {
+    public CourseUpdater(Courses courses, Degrees degrees, Universities universities) {
         this.courses = courses;
+        this.degrees = degrees;
         this.universities = universities;
     }
 
@@ -28,7 +31,7 @@ public class CourseUpdater implements UpdateCourse {
                     throw new IllegalArgumentException("Course with the same short name and full name already exists");
                 });
         degreeIds.forEach(degreeId -> {
-            if (universities.findById(degreeId).isEmpty()) {
+            if (degrees.findById(degreeId).isEmpty()) {
                 throw new IllegalArgumentException("Degree with ID " + degreeId + " does not exist");
             }
         });

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseUpdater.java
@@ -19,7 +19,7 @@ public class CourseUpdater implements UpdateCourse {
         this.universities = universities;
     }
 
-    public Course updateCourse(UUID id, String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds) {
+    public Course update(UUID id, String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds) {
         // TODO: better error handling
         Course existingCourse = courses.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Course does not exist"));

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseUpdater.java
@@ -1,0 +1,52 @@
+package com.mufidgu.pastpapers.domain.course;
+
+import com.mufidgu.pastpapers.domain.course.api.UpdateCourse;
+import com.mufidgu.pastpapers.domain.course.spi.Courses;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import ddd.DomainService;
+
+import java.util.List;
+import java.util.UUID;
+
+@DomainService
+public class CourseUpdater implements UpdateCourse {
+
+    private final Courses courses;
+    private final Universities universities;
+
+    public CourseUpdater(Courses courses, Universities universities) {
+        this.courses = courses;
+        this.universities = universities;
+    }
+
+    public Course updateCourse(UUID id, String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds) {
+        // TODO: better error handling
+        Course existingCourse = courses.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Course does not exist"));
+        courses.findByShortNameAndFullName(shortName, fullName)
+                .ifPresent(course -> {
+                    throw new IllegalArgumentException("Course with the same short name and full name already exists");
+                });
+        degreeIds.forEach(degreeId -> {
+            if (universities.findById(degreeId).isEmpty()) {
+                throw new IllegalArgumentException("Degree with ID " + degreeId + " does not exist");
+            }
+        });
+        universityIds.forEach(universityId -> {
+            if (universities.findById(universityId).isEmpty()) {
+                throw new IllegalArgumentException("University with ID " + universityId + " does not exist");
+            }
+        });
+
+        // TODO: Revisit this when adding database to project
+        return courses.save(
+                new Course(
+                        existingCourse.id(),
+                        shortName,
+                        fullName,
+                        degreeIds,
+                        universityIds
+                )
+        );
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseUpdater.java
@@ -27,8 +27,10 @@ public class CourseUpdater implements UpdateCourse {
         Course existingCourse = courses.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Course does not exist"));
         courses.findByShortNameAndFullName(shortName, fullName)
-                .ifPresent(course -> {
-                    throw new IllegalArgumentException("Course with the same short name and full name already exists");
+                .ifPresent(c -> {
+                    if (!c.id().equals(existingCourse.id())) {
+                        throw new IllegalArgumentException("Course with the same short name and full name already exists");
+                    }
                 });
         degreeIds.forEach(degreeId -> {
             if (degrees.findById(degreeId).isEmpty()) {

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/api/AddCourse.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/api/AddCourse.java
@@ -6,5 +6,5 @@ import java.util.List;
 import java.util.UUID;
 
 public interface AddCourse {
-    Course addCourse(String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds);
+    Course add(String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds);
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/api/AddCourse.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/api/AddCourse.java
@@ -1,0 +1,10 @@
+package com.mufidgu.pastpapers.domain.course.api;
+
+import com.mufidgu.pastpapers.domain.course.Course;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AddCourse {
+    Course addCourse(String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/api/DeleteCourse.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/api/DeleteCourse.java
@@ -1,0 +1,7 @@
+package com.mufidgu.pastpapers.domain.course.api;
+
+import java.util.UUID;
+
+public interface DeleteCourse {
+    void delete(UUID courseId);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/api/FetchCourse.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/api/FetchCourse.java
@@ -1,0 +1,9 @@
+package com.mufidgu.pastpapers.domain.course.api;
+
+import com.mufidgu.pastpapers.domain.course.Course;
+
+import java.util.List;
+
+public interface FetchCourse {
+    List<Course> fetchAll();
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/api/UpdateCourse.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/api/UpdateCourse.java
@@ -1,0 +1,10 @@
+package com.mufidgu.pastpapers.domain.course.api;
+
+import com.mufidgu.pastpapers.domain.course.Course;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UpdateCourse {
+    Course updateCourse(UUID id, String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/api/UpdateCourse.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/api/UpdateCourse.java
@@ -6,5 +6,5 @@ import java.util.List;
 import java.util.UUID;
 
 public interface UpdateCourse {
-    Course updateCourse(UUID id, String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds);
+    Course update(UUID id, String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds);
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/spi/Courses.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/spi/Courses.java
@@ -1,0 +1,15 @@
+package com.mufidgu.pastpapers.domain.course.spi;
+
+import com.mufidgu.pastpapers.domain.course.Course;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface Courses {
+    Course save(Course course);
+    void delete(UUID id);
+    Optional<Course> findById(UUID id);
+    Optional<Course> findByShortNameAndFullName(String shortName, String fullName);
+    List<Course> findAll();
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/spi/Courses.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/spi/Courses.java
@@ -8,8 +8,12 @@ import java.util.UUID;
 
 public interface Courses {
     Course save(Course course);
+
     void delete(UUID id);
+
     Optional<Course> findById(UUID id);
+
     Optional<Course> findByShortNameAndFullName(String shortName, String fullName);
+
     List<Course> findAll();
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/spi/stub/InMemoryCourses.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/spi/stub/InMemoryCourses.java
@@ -2,12 +2,14 @@ package com.mufidgu.pastpapers.domain.course.spi.stub;
 
 import com.mufidgu.pastpapers.domain.course.Course;
 import com.mufidgu.pastpapers.domain.course.spi.Courses;
+import ddd.Stub;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@Stub
 public class InMemoryCourses implements Courses {
 
     HashMap<UUID, Course> courses = new HashMap<>();

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/spi/stub/InMemoryCourses.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/spi/stub/InMemoryCourses.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Stub
 public class InMemoryCourses implements Courses {
 
-    HashMap<UUID, Course> courses = new HashMap<>();
+    private final HashMap<UUID, Course> courses = new HashMap<>();
 
     public Course save(Course course) {
         courses.put(course.id(), course);

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/spi/stub/InMemoryCourses.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/spi/stub/InMemoryCourses.java
@@ -1,0 +1,37 @@
+package com.mufidgu.pastpapers.domain.course.spi.stub;
+
+import com.mufidgu.pastpapers.domain.course.Course;
+import com.mufidgu.pastpapers.domain.course.spi.Courses;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class InMemoryCourses implements Courses {
+
+    HashMap<UUID, Course> courses = new HashMap<>();
+
+    public Course save(Course course) {
+        courses.put(course.id(), course);
+        return course;
+    }
+
+    public void delete(UUID id) {
+        courses.remove(id);
+    }
+
+    public Optional<Course> findById(UUID id) {
+        return Optional.ofNullable(courses.get(id));
+    }
+
+    public Optional<Course> findByShortNameAndFullName(String shortName, String fullName) {
+        return courses.values().stream()
+                .filter(course -> course.shortName().equals(shortName) && course.fullName().equals(fullName))
+                .findFirst();
+    }
+
+    public List<Course> findAll() {
+        return List.copyOf(courses.values());
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeUpdater.java
@@ -31,6 +31,7 @@ public class DegreeUpdater implements UpdateDegree {
             }
         });
 
+        // TODO: Revisit this when adding database to project
         return degrees.save(
                 new Degree(degree.id(), shortName, fullName, universities)
         );

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeUpdater.java
@@ -23,7 +23,9 @@ public class DegreeUpdater implements UpdateDegree {
         // TODO: better exception handling
         Degree degree = degrees.findById(id).orElseThrow(() -> new IllegalArgumentException("Degree does not exist"));
         degrees.findByShortNameAndFullName(shortName, fullName).ifPresent(d -> {
-            throw new IllegalArgumentException("Degree with the same short name and full name already exists");
+            if (!d.id().equals(degree.id())) {
+                throw new IllegalArgumentException("Degree with the same short name and full name already exists");
+            }
         });
         universities.forEach(universityId -> {
             if (this.universities.findById(universityId) == null) {

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/Degrees.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/Degrees.java
@@ -8,8 +8,12 @@ import java.util.UUID;
 
 public interface Degrees {
     Degree save(Degree degree);
+
     Optional<Degree> findByShortNameAndFullName(String shortName, String fullName);
+
     Optional<Degree> findById(UUID id);
+
     void delete(UUID id);
+
     List<Degree> findAll();
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/stub/InMemoryDegrees.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/stub/InMemoryDegrees.java
@@ -4,7 +4,10 @@ import com.mufidgu.pastpapers.domain.degree.Degree;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
 import ddd.Stub;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Stub
 public class InMemoryDegrees implements Degrees {

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/stub/InMemoryDegrees.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/stub/InMemoryDegrees.java
@@ -1,4 +1,4 @@
-package com.mufidgu.pastpapers.domain.degree.spi.stubs;
+package com.mufidgu.pastpapers.domain.degree.spi.stub;
 
 import com.mufidgu.pastpapers.domain.degree.Degree;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
@@ -31,7 +31,7 @@ public class InMemoryDegrees implements Degrees {
     }
 
     public List<Degree> findAll() {
-        return new ArrayList<>(degrees.values());
+        return List.copyOf(degrees.values());
     }
 
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/stub/InMemoryDegrees.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/spi/stub/InMemoryDegrees.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Stub
 public class InMemoryDegrees implements Degrees {
 
-    HashMap<UUID, Degree> degrees = new HashMap<>();
+    private final HashMap<UUID, Degree> degrees = new HashMap<>();
 
     public Degree save(Degree degree) {
         degrees.put(degree.id(), degree);

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityFetcher.java
@@ -9,11 +9,11 @@ import java.util.List;
 @DomainService
 public class UniversityFetcher implements FetchUniversity {
 
+    private final Universities universities;
+
     public UniversityFetcher(Universities universities) {
         this.universities = universities;
     }
-
-    private final Universities universities;
 
     public List<University> fetchAll() {
         return universities.findAll();

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityFetcher.java
@@ -16,6 +16,6 @@ public class UniversityFetcher implements FetchUniversity {
     private final Universities universities;
 
     public List<University> fetchAll() {
-        return universities.getAll();
+        return universities.findAll();
     }
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityUpdater.java
@@ -21,7 +21,9 @@ public class UniversityUpdater implements UpdateUniversity {
                 () -> new IllegalArgumentException("University does not exist.")
         );
         universities.findByShortNameAndFullName(shortName, fullName).ifPresent(u -> {
-            throw new IllegalArgumentException("University with the same short name and full name already exists.");
+            if (!u.id().equals(id)) {
+                throw new IllegalArgumentException("University with the same short name and full name already exists.");
+            }
         });
 
         // TODO: Revisit this when adding database to project

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/spi/Universities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/spi/Universities.java
@@ -8,8 +8,12 @@ import java.util.UUID;
 
 public interface Universities {
     University save(University university);
+
     Optional<University> findByShortNameAndFullName(String shortName, String fullName);
+
     List<University> findAll();
+
     Optional<University> findById(UUID id);
+
     void delete(UUID id);
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/spi/Universities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/spi/Universities.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public interface Universities {
     University save(University university);
     Optional<University> findByShortNameAndFullName(String shortName, String fullName);
-    List<University> getAll();
+    List<University> findAll();
     Optional<University> findById(UUID id);
     void delete(UUID id);
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/spi/stub/InMemoryUniversities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/spi/stub/InMemoryUniversities.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Stub
 public class InMemoryUniversities implements Universities {
 
-    HashMap<UUID, University> universities = new HashMap<>();
+    private final HashMap<UUID, University> universities = new HashMap<>();
 
     public University save(University university) {
         universities.put(university.id(), university);

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/spi/stub/InMemoryUniversities.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/spi/stub/InMemoryUniversities.java
@@ -1,4 +1,4 @@
-package com.mufidgu.pastpapers.domain.university.spi.stubs;
+package com.mufidgu.pastpapers.domain.university.spi.stub;
 
 import com.mufidgu.pastpapers.domain.university.University;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
@@ -25,7 +25,7 @@ public class InMemoryUniversities implements Universities {
                 .findFirst();
     }
 
-    public List<University> getAll() {
+    public List<University> findAll() {
         return List.copyOf(universities.values());
     }
 

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseController.java
@@ -1,0 +1,100 @@
+package com.mufidgu.pastpapers.infrastructure.controller.course;
+
+import com.mufidgu.pastpapers.domain.course.Course;
+import com.mufidgu.pastpapers.domain.course.api.AddCourse;
+import com.mufidgu.pastpapers.domain.course.api.DeleteCourse;
+import com.mufidgu.pastpapers.domain.course.api.FetchCourse;
+import com.mufidgu.pastpapers.domain.course.api.UpdateCourse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Validated
+@RestController
+@RequestMapping("/course")
+public class CourseController {
+
+    private final AddCourse courseAdder;
+    private final UpdateCourse courseUpdater;
+    private final DeleteCourse courseDeleter;
+    private final FetchCourse courseFetcher;
+
+    public CourseController(
+            AddCourse courseAdder,
+            UpdateCourse courseUpdater,
+            DeleteCourse courseDeleter,
+            FetchCourse courseFetcher) {
+        this.courseAdder = courseAdder;
+        this.courseUpdater = courseUpdater;
+        this.courseDeleter = courseDeleter;
+        this.courseFetcher = courseFetcher;
+    }
+
+    // TODO: Admin Only
+    // Validation, Already Exists, Degree/University Does Not Exist
+    @PostMapping("/add")
+    public ResponseEntity<CourseResource> addCourse(@Valid @RequestBody CourseRequest request) {
+        Course course = courseAdder.add(
+                request.shortName,
+                request.fullName,
+                request.degreeIds,
+                request.universityIds
+        );
+        return ResponseEntity.ok(new CourseResource(
+                course.id(),
+                course.shortName(),
+                course.fullName(),
+                course.degreeIds(),
+                course.universityIds()
+        ));
+    }
+
+    // TODO: Admin Only
+    @PutMapping("/update")
+    public ResponseEntity<CourseResource> updateCourse(
+            @Valid @RequestParam String courseId,
+            @Valid @RequestBody CourseRequest request
+    ) {
+        UUID id = UUID.fromString(courseId);
+        Course course = courseUpdater.update(
+                id,
+                request.shortName,
+                request.fullName,
+                request.degreeIds,
+                request.universityIds
+        );
+        return ResponseEntity.ok(new CourseResource(
+                course.id(),
+                course.shortName(),
+                course.fullName(),
+                course.degreeIds(),
+                course.universityIds()
+        ));
+    }
+
+    // TODO: Admin Only
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> deleteCourse(@RequestParam String courseId) {
+        UUID id = UUID.fromString(courseId);
+        courseDeleter.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // TODO: Registered Users Only
+    @GetMapping("/all")
+    public ResponseEntity<Iterable<CourseResource>> getAllCourses() {
+        var courses = courseFetcher.fetchAll();
+        return ResponseEntity.ok(courses.stream()
+                .map(c -> new CourseResource(
+                        c.id(),
+                        c.shortName(),
+                        c.fullName(),
+                        c.degreeIds(),
+                        c.universityIds()))
+                .toList());
+    }
+
+}

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseController.java
@@ -6,6 +6,7 @@ import com.mufidgu.pastpapers.domain.course.api.DeleteCourse;
 import com.mufidgu.pastpapers.domain.course.api.FetchCourse;
 import com.mufidgu.pastpapers.domain.course.api.UpdateCourse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -56,7 +57,7 @@ public class CourseController {
     // TODO: Admin Only
     @PutMapping("/update")
     public ResponseEntity<CourseResource> updateCourse(
-            @Valid @RequestParam String courseId,
+            @NotBlank @RequestParam String courseId,
             @Valid @RequestBody CourseRequest request
     ) {
         UUID id = UUID.fromString(courseId);
@@ -78,7 +79,7 @@ public class CourseController {
 
     // TODO: Admin Only
     @DeleteMapping("/delete")
-    public ResponseEntity<Void> deleteCourse(@RequestParam String courseId) {
+    public ResponseEntity<Void> deleteCourse(@NotBlank @RequestParam String courseId) {
         UUID id = UUID.fromString(courseId);
         courseDeleter.delete(id);
         return ResponseEntity.status(HttpStatus.OK).build();

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseController.java
@@ -6,6 +6,7 @@ import com.mufidgu.pastpapers.domain.course.api.DeleteCourse;
 import com.mufidgu.pastpapers.domain.course.api.FetchCourse;
 import com.mufidgu.pastpapers.domain.course.api.UpdateCourse;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -80,7 +81,7 @@ public class CourseController {
     public ResponseEntity<Void> deleteCourse(@RequestParam String courseId) {
         UUID id = UUID.fromString(courseId);
         courseDeleter.delete(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     // TODO: Registered Users Only

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseRequest.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseRequest.java
@@ -1,0 +1,21 @@
+package com.mufidgu.pastpapers.infrastructure.controller.course;
+
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
+import java.util.UUID;
+
+public class CourseRequest {
+    @NotBlank
+    @Length(min = 2, max = 30)
+    public String shortName;
+
+    @NotBlank
+    @Length(min = 3, max = 100)
+    public String fullName;
+
+    public List<UUID> degreeIds;
+
+    public List<UUID> universityIds;
+}

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseResource.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseResource.java
@@ -1,0 +1,13 @@
+package com.mufidgu.pastpapers.infrastructure.controller.course;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CourseResource(
+        UUID id,
+        String shortName,
+        String fullName,
+        List<UUID> degreeIds,
+        List<UUID> universityIds
+) {
+}

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeController.java
@@ -12,7 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @Validated

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseControllerTest.java
@@ -1,0 +1,138 @@
+package com.mufidgu.pastpapers.infrastructure.controller.course;
+
+import com.mufidgu.pastpapers.domain.course.Course;
+import com.mufidgu.pastpapers.domain.course.spi.Courses;
+import com.mufidgu.pastpapers.domain.degree.Degree;
+import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
+import com.mufidgu.pastpapers.domain.university.University;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import com.mufidgu.pastpapers.infrastructure.configuration.DomainConfiguration;
+import ddd.Stub;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+@Import(DomainConfiguration.class)
+public class CourseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private Courses courses;
+
+    @Autowired
+    private Degrees degrees;
+
+    @Autowired
+    private Universities universities;
+
+    private Degree testDegree;
+    private University testUniversity;
+
+    @BeforeEach
+    void setUp() {
+        // Create test degree and university to use in course tests
+        testDegree = degrees.save(new Degree("CS", "Computer Science", List.of()));
+        testUniversity = universities.save(new University("MIT", "Massachusetts Institute of Technology"));
+    }
+
+    @Test
+    void should_add_course() throws Exception {
+        mockMvc.perform(
+                        post("/course/add")
+                                .contentType("application/json")
+                                .content(String.format("""
+                                        {
+                                            "shortName": "AI",
+                                            "fullName": "Artificial Intelligence",
+                                            "degreeIds": ["%s"],
+                                            "universityIds": ["%s"]
+                                        }
+                                        """, testDegree.id(), testUniversity.id()))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andExpect(jsonPath("$.shortName").value("AI"))
+                .andExpect(jsonPath("$.fullName").value("Artificial Intelligence"))
+                .andExpect(jsonPath("$.degreeIds[0]").value(testDegree.id().toString()))
+                .andExpect(jsonPath("$.universityIds[0]").value(testUniversity.id().toString()));
+    }
+
+    @Test
+    void should_return_all_courses() throws Exception {
+        // Create a test course
+        courses.save(new Course("ML", "Machine Learning", List.of(testDegree.id()), List.of(testUniversity.id())));
+
+        mockMvc.perform(
+                        get("/course/all")
+                                .contentType("application/json")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isNotEmpty())
+                .andExpect(jsonPath("$[?(@.shortName == 'ML')]").exists());
+    }
+
+    @Test
+    void should_update_course() throws Exception {
+        // Create a test course
+        Course course = courses.save(new Course("DS", "Data Science", List.of(testDegree.id()), List.of(testUniversity.id())));
+
+        mockMvc.perform(
+                        put("/course/update?courseId=" + course.id())
+                                .contentType("application/json")
+                                .content(String.format("""
+                                        {
+                                            "shortName": "DataSci",
+                                            "fullName": "Data Science and Analytics",
+                                            "degreeIds": ["%s"],
+                                            "universityIds": ["%s"]
+                                        }
+                                        """, testDegree.id(), testUniversity.id()))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(course.id().toString()))
+                .andExpect(jsonPath("$.shortName").value("DataSci"))
+                .andExpect(jsonPath("$.fullName").value("Data Science and Analytics"))
+                .andExpect(jsonPath("$.degreeIds[0]").value(testDegree.id().toString()))
+                .andExpect(jsonPath("$.universityIds[0]").value(testUniversity.id().toString()));
+    }
+
+    @Test
+    void should_delete_course() throws Exception {
+        // Create a test course
+        Course course = courses.save(new Course("CyberSec", "Cyber Security", List.of(testDegree.id()), List.of(testUniversity.id())));
+
+        mockMvc.perform(
+                        delete("/course/delete?courseId=" + course.id())
+                )
+                .andExpect(status().isOk());
+
+        // Verify that the course is deleted
+        mockMvc.perform(get("/course/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.shortName == 'CyberSec')]").doesNotExist());
+    }
+
+    @TestConfiguration
+    @ComponentScan(
+            basePackageClasses = {Course.class, Degree.class, University.class},
+            includeFilters = {@ComponentScan.Filter(type = FilterType.ANNOTATION, classes = {Stub.class})})
+    static class StubConfiguration {
+    }
+}
+

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeControllerTest.java
@@ -17,9 +17,9 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
-import java.util.UUID;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -49,16 +49,16 @@ public class DegreeControllerTest {
     @Test
     void should_add_degree() throws Exception {
         mockMvc.perform(
-                post("/degree/add")
-                        .contentType("application/json")
-                        .content(String.format("""
-                                {
-                                    "shortName": "CS",
-                                    "fullName": "Computer Science",
-                                    "universityIds": ["%s"]
-                                }
-                                """, testUniversity.id()))
-        )
+                        post("/degree/add")
+                                .contentType("application/json")
+                                .content(String.format("""
+                                        {
+                                            "shortName": "CS",
+                                            "fullName": "Computer Science",
+                                            "universityIds": ["%s"]
+                                        }
+                                        """, testUniversity.id()))
+                )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").isNotEmpty())
                 .andExpect(jsonPath("$.shortName").value("CS"))
@@ -72,9 +72,9 @@ public class DegreeControllerTest {
         degrees.save(new Degree("Math", "Mathematics", List.of(testUniversity.id())));
 
         mockMvc.perform(
-                get("/degree/all")
-                        .contentType("application/json")
-        )
+                        get("/degree/all")
+                                .contentType("application/json")
+                )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$").isNotEmpty())
@@ -87,16 +87,16 @@ public class DegreeControllerTest {
         Degree degree = degrees.save(new Degree("Phys", "Physics", List.of(testUniversity.id())));
 
         mockMvc.perform(
-                post("/degree/update?degreeId=" + degree.id())
-                        .contentType("application/json")
-                        .content(String.format("""
-                                {
-                                    "shortName": "Physics",
-                                    "fullName": "Physics and Astronomy",
-                                    "universityIds": ["%s", "%s"]
-                                }
-                                """, testUniversity.id(), secondTestUniversity.id()))
-        )
+                        post("/degree/update?degreeId=" + degree.id())
+                                .contentType("application/json")
+                                .content(String.format("""
+                                        {
+                                            "shortName": "Physics",
+                                            "fullName": "Physics and Astronomy",
+                                            "universityIds": ["%s", "%s"]
+                                        }
+                                        """, testUniversity.id(), secondTestUniversity.id()))
+                )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(degree.id().toString()))
                 .andExpect(jsonPath("$.shortName").value("Physics"))
@@ -110,8 +110,8 @@ public class DegreeControllerTest {
         Degree degree = degrees.save(new Degree("Bio", "Biology", List.of(testUniversity.id())));
 
         mockMvc.perform(
-                post("/degree/delete?degreeId=" + degree.id())
-        )
+                        post("/degree/delete?degreeId=" + degree.id())
+                )
                 .andExpect(status().isOk());
 
         // Verify that the degree is deleted

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityControllerTest.java
@@ -1,6 +1,5 @@
 package com.mufidgu.pastpapers.infrastructure.controller.university;
 
-import com.mufidgu.pastpapers.Application;
 import com.mufidgu.pastpapers.domain.university.University;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import com.mufidgu.pastpapers.infrastructure.configuration.DomainConfiguration;
@@ -31,15 +30,15 @@ public class UniversityControllerTest {
     @Test
     void should_add_university() throws Exception {
         mockMvc.perform(
-                post("/university/add")
-                        .contentType("application/json")
-                        .content("""
-                                {
-                                    "shortName": "MIT",
-                                    "fullName": "Massachusetts Institute of Technology"
-                                }
-                                """)
-        )
+                        post("/university/add")
+                                .contentType("application/json")
+                                .content("""
+                                        {
+                                            "shortName": "MIT",
+                                            "fullName": "Massachusetts Institute of Technology"
+                                        }
+                                        """)
+                )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").isNotEmpty())
                 .andExpect(jsonPath("$.shortName").value("MIT"))
@@ -65,15 +64,15 @@ public class UniversityControllerTest {
         University university = universities.save(new University("Harvard", "Harvard University"));
 
         mockMvc.perform(
-                put("/university/update?universityId=" + university.id())
-                        .contentType("application/json")
-                        .content("""
-                                {
-                                    "shortName": "Harvard Updated",
-                                    "fullName": "Harvard University Updated"
-                                }
-                                """)
-        )
+                        put("/university/update?universityId=" + university.id())
+                                .contentType("application/json")
+                                .content("""
+                                        {
+                                            "shortName": "Harvard Updated",
+                                            "fullName": "Harvard University Updated"
+                                        }
+                                        """)
+                )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(university.id().toString()))
                 .andExpect(jsonPath("$.shortName").value("Harvard Updated"))
@@ -86,8 +85,8 @@ public class UniversityControllerTest {
         University university = universities.save(new University("Yale", "Yale University"));
 
         mockMvc.perform(
-                delete("/university/delete?universityId=" + university.id())
-        )
+                        delete("/university/delete?universityId=" + university.id())
+                )
                 .andExpect(status().isOk());
 
         // Verify that the university is deleted


### PR DESCRIPTION
This pull request introduces a new "Course" domain to the project, providing full CRUD (Create, Read, Update, Delete) functionality for courses, along with in-memory persistence and REST API endpoints. It also standardizes the interfaces and in-memory implementations for related domains (Degree and University), and makes minor improvements to the bug report template.

**Key changes:**

### Course Domain Implementation

* Added the `Course` record and its domain services: `CourseAdder`, `CourseUpdater`, `CourseDeleter`, and `CourseFetcher`, each handling the respective CRUD operations with validation and error handling.
* Defined API interfaces for course operations (`AddCourse`, `UpdateCourse`, `DeleteCourse`, `FetchCourse`) and a persistence SPI (`Courses`).
* Implemented an in-memory repository for courses (`InMemoryCourses`).

### REST API for Courses

* Introduced `CourseController` with endpoints for adding, updating, deleting, and fetching all courses, using request validation and response mapping.
* Added `CourseRequest` DTO for validating incoming course data.

### Degree and University SPI Standardization

* Refactored the Degree and University SPI interfaces and their in-memory implementations to use consistent method names (e.g., `findAll` instead of `getAll`) and package naming (`stub` instead of `stubs`).

### Minor Improvements

* Updated the bug report issue template to improve clarity in the reproduction steps and environment information.
* Added TODO comments for future enhancements, such as better error handling and access control in controllers and domain services.