### PR TITLE
feat: implement instructor management with add, update, delete, and f…

### DIFF
--- a/src/main/java/com/mufidgu/pastpapers/domain/course/spi/Courses.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/spi/Courses.java
@@ -8,12 +8,8 @@ import java.util.UUID;
 
 public interface Courses {
     Course save(Course course);
-
     void delete(UUID id);
-
     Optional<Course> findById(UUID id);
-
     Optional<Course> findByShortNameAndFullName(String shortName, String fullName);
-
     List<Course> findAll();
 }

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/Instructor.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/Instructor.java
@@ -1,0 +1,15 @@
+package com.mufidgu.pastpapers.domain.instructor;
+
+import java.util.List;
+import java.util.UUID;
+
+public record Instructor(
+        UUID id,
+        String fullName,
+        List<UUID> courseIds,
+        List<UUID> universityIds
+) {
+    public Instructor(String fullName, List<UUID> courseIds, List<UUID> universityIds) {
+        this(UUID.randomUUID(), fullName, courseIds, universityIds);
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorAdder.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorAdder.java
@@ -1,0 +1,41 @@
+package com.mufidgu.pastpapers.domain.instructor;
+
+import com.mufidgu.pastpapers.domain.instructor.api.AddInstructor;
+import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
+import com.mufidgu.pastpapers.domain.course.spi.Courses;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import ddd.DomainService;
+
+import java.util.List;
+import java.util.UUID;
+
+@DomainService
+public class InstructorAdder implements AddInstructor {
+
+    private final Instructors instructors;
+    private final Courses courses;
+    private final Universities universities;
+
+    public InstructorAdder(Instructors instructors, Courses courses, Universities universities) {
+        this.instructors = instructors;
+        this.courses = courses;
+        this.universities = universities;
+    }
+
+    @Override
+    public Instructor add(String fullName, List<UUID> courseIds, List<UUID> universityIds) {
+        instructors.findByFullName(fullName)
+                .ifPresent(instructor -> {
+                    throw new IllegalArgumentException("Instructor with the same full name already exists");
+                });
+
+        courseIds.forEach(id -> courses.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Course with ID " + id + " does not exist")));
+
+        universityIds.forEach(id -> universities.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("University with ID " + id + " does not exist")));
+
+        Instructor instructor = new Instructor(fullName, courseIds, universityIds);
+        return instructors.save(instructor);
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorDeleter.java
@@ -1,0 +1,24 @@
+package com.mufidgu.pastpapers.domain.instructor;
+
+import com.mufidgu.pastpapers.domain.instructor.api.DeleteInstructor;
+import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
+import ddd.DomainService;
+
+import java.util.UUID;
+
+@DomainService
+public class InstructorDeleter implements DeleteInstructor {
+
+    private final Instructors instructors;
+
+    public InstructorDeleter(Instructors instructors) {
+        this.instructors = instructors;
+    }
+
+    @Override
+    public void delete(UUID instructorId) {
+        instructors.findById(instructorId)
+                .orElseThrow(() -> new IllegalArgumentException("Instructor does not exist"));
+        instructors.delete(instructorId);
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorFetcher.java
@@ -1,0 +1,22 @@
+package com.mufidgu.pastpapers.domain.instructor;
+
+import com.mufidgu.pastpapers.domain.instructor.api.FetchInstructor;
+import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
+import ddd.DomainService;
+
+import java.util.List;
+
+@DomainService
+public class InstructorFetcher implements FetchInstructor {
+
+    private final Instructors instructors;
+
+    public InstructorFetcher(Instructors instructors) {
+        this.instructors = instructors;
+    }
+
+    @Override
+    public List<Instructor> fetchAll() {
+        return instructors.findAll();
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorUpdater.java
@@ -1,0 +1,58 @@
+package com.mufidgu.pastpapers.domain.instructor;
+
+import com.mufidgu.pastpapers.domain.instructor.api.UpdateInstructor;
+import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
+import com.mufidgu.pastpapers.domain.course.spi.Courses;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import ddd.DomainService;
+
+import java.util.List;
+import java.util.UUID;
+
+@DomainService
+public class InstructorUpdater implements UpdateInstructor {
+
+    private final Instructors instructors;
+    private final Courses courses;
+    private final Universities universities;
+
+    public InstructorUpdater(Instructors instructors, Courses courses, Universities universities) {
+        this.instructors = instructors;
+        this.courses = courses;
+        this.universities = universities;
+    }
+
+    @Override
+    public Instructor update(UUID id, String fullName, List<UUID> courseIds, List<UUID> universityIds) {
+        Instructor existingInstructor = instructors.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Instructor does not exist"));
+
+        instructors.findByFullName(fullName)
+                .ifPresent(instructor -> {
+                    if (!instructor.id().equals(existingInstructor.id())) {
+                        throw new IllegalArgumentException("Instructor with the same full name already exists");
+                    }
+                });
+
+        courseIds.forEach(courseId -> {
+            if (courses.findById(courseId).isEmpty()) {
+                throw new IllegalArgumentException("Course with ID " + courseId + " does not exist");
+            }
+        });
+
+        universityIds.forEach(universityId -> {
+            if (universities.findById(universityId).isEmpty()) {
+                throw new IllegalArgumentException("University with ID " + universityId + " does not exist");
+            }
+        });
+
+        return instructors.save(
+                new Instructor(
+                        existingInstructor.id(),
+                        fullName,
+                        courseIds,
+                        universityIds
+                )
+        );
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/api/AddInstructor.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/api/AddInstructor.java
@@ -1,0 +1,10 @@
+package com.mufidgu.pastpapers.domain.instructor.api;
+
+import com.mufidgu.pastpapers.domain.instructor.Instructor;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AddInstructor {
+    Instructor add(String fullName, List<UUID> courseIds, List<UUID> universityIds);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/api/DeleteInstructor.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/api/DeleteInstructor.java
@@ -1,0 +1,7 @@
+package com.mufidgu.pastpapers.domain.instructor.api;
+
+import java.util.UUID;
+
+public interface DeleteInstructor {
+    void delete(UUID id);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/api/FetchInstructor.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/api/FetchInstructor.java
@@ -1,0 +1,9 @@
+package com.mufidgu.pastpapers.domain.instructor.api;
+
+import com.mufidgu.pastpapers.domain.instructor.Instructor;
+
+import java.util.List;
+
+public interface FetchInstructor {
+    List<Instructor> fetchAll();
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/api/UpdateInstructor.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/api/UpdateInstructor.java
@@ -1,0 +1,10 @@
+package com.mufidgu.pastpapers.domain.instructor.api;
+
+import com.mufidgu.pastpapers.domain.instructor.Instructor;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UpdateInstructor {
+    Instructor update(UUID id, String fullName, List<UUID> courseIds, List<UUID> universityIds);
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/spi/Instructors.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/spi/Instructors.java
@@ -1,0 +1,15 @@
+package com.mufidgu.pastpapers.domain.instructor.spi;
+
+import com.mufidgu.pastpapers.domain.instructor.Instructor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface Instructors {
+    Instructor save(Instructor instructor);
+    void delete(UUID id);
+    Optional<Instructor> findById(UUID id);
+    Optional<Instructor> findByFullName(String fullName);
+    List<Instructor> findAll();
+}

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/spi/stub/InMemoryInstructors.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/spi/stub/InMemoryInstructors.java
@@ -1,0 +1,44 @@
+package com.mufidgu.pastpapers.domain.instructor.spi.stub;
+
+import com.mufidgu.pastpapers.domain.instructor.Instructor;
+import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
+import ddd.Stub;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Stub
+public class InMemoryInstructors implements Instructors {
+
+    private final HashMap<UUID, Instructor> instructors = new HashMap<>();
+
+    @Override
+    public Instructor save(Instructor instructor) {
+        instructors.put(instructor.id(), instructor);
+        return instructor;
+    }
+
+    @Override
+    public void delete(UUID id) {
+        instructors.remove(id);
+    }
+
+    @Override
+    public Optional<Instructor> findById(UUID id) {
+        return Optional.ofNullable(instructors.get(id));
+    }
+
+    @Override
+    public Optional<Instructor> findByFullName(String fullName) {
+        return instructors.values().stream()
+                .filter(instructor -> instructor.fullName().equals(fullName))
+                .findFirst();
+    }
+
+    @Override
+    public List<Instructor> findAll() {
+        return List.copyOf(instructors.values());
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorController.java
@@ -1,0 +1,95 @@
+package com.mufidgu.pastpapers.infrastructure.controller.instructor;
+
+import com.mufidgu.pastpapers.domain.instructor.Instructor;
+import com.mufidgu.pastpapers.domain.instructor.api.AddInstructor;
+import com.mufidgu.pastpapers.domain.instructor.api.DeleteInstructor;
+import com.mufidgu.pastpapers.domain.instructor.api.FetchInstructor;
+import com.mufidgu.pastpapers.domain.instructor.api.UpdateInstructor;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Validated
+@RestController
+@RequestMapping("/instructor")
+public class InstructorController {
+
+    private final AddInstructor instructorAdder;
+    private final UpdateInstructor instructorUpdater;
+    private final DeleteInstructor instructorDeleter;
+    private final FetchInstructor instructorFetcher;
+
+    public InstructorController(
+            AddInstructor instructorAdder,
+            UpdateInstructor instructorUpdater,
+            DeleteInstructor instructorDeleter,
+            FetchInstructor instructorFetcher) {
+        this.instructorAdder = instructorAdder;
+        this.instructorUpdater = instructorUpdater;
+        this.instructorDeleter = instructorDeleter;
+        this.instructorFetcher = instructorFetcher;
+    }
+
+    // TODO: Admin Only
+    @PostMapping("/add")
+    public ResponseEntity<InstructorResource> addInstructor(@Valid @RequestBody InstructorRequest request) {
+        Instructor instructor = instructorAdder.add(
+                request.fullName,
+                request.courseIds,
+                request.universityIds
+        );
+        return ResponseEntity.ok(new InstructorResource(
+                instructor.id(),
+                instructor.fullName(),
+                instructor.courseIds(),
+                instructor.universityIds()
+        ));
+    }
+
+    // TODO: Admin Only
+    @PutMapping("/update")
+    public ResponseEntity<InstructorResource> updateInstructor(
+            @NotBlank @RequestParam String instructorId,
+            @Valid @RequestBody InstructorRequest request
+    ) {
+        UUID id = UUID.fromString(instructorId);
+        Instructor instructor = instructorUpdater.update(
+                id,
+                request.fullName,
+                request.courseIds,
+                request.universityIds
+        );
+        return ResponseEntity.ok(new InstructorResource(
+                instructor.id(),
+                instructor.fullName(),
+                instructor.courseIds(),
+                instructor.universityIds()
+        ));
+    }
+
+    // TODO: Admin Only
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> deleteInstructor(@NotBlank @RequestParam String instructorId) {
+        UUID id = UUID.fromString(instructorId);
+        instructorDeleter.delete(id);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    // TODO: Registered Users Only
+    @GetMapping("/all")
+    public ResponseEntity<Iterable<InstructorResource>> getAllInstructors() {
+        var instructors = instructorFetcher.fetchAll();
+        return ResponseEntity.ok(instructors.stream()
+                .map(i -> new InstructorResource(
+                        i.id(),
+                        i.fullName(),
+                        i.courseIds(),
+                        i.universityIds()))
+                .toList());
+    }
+}

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorRequest.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorRequest.java
@@ -1,0 +1,16 @@
+package com.mufidgu.pastpapers.infrastructure.controller.instructor;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
+import java.util.UUID;
+
+public class InstructorRequest {
+    @NotBlank
+    @Length(min = 2, max = 30)
+    public String fullName;
+    public List<UUID> courseIds;
+    public List<UUID> universityIds;
+}

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorResource.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorResource.java
@@ -1,0 +1,12 @@
+package com.mufidgu.pastpapers.infrastructure.controller.instructor;
+
+import java.util.List;
+import java.util.UUID;
+
+public record InstructorResource(
+        UUID id,
+        String fullName,
+        List<UUID> courseIds,
+        List<UUID> universityIds
+) {
+}

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorControllerTest.java
@@ -1,0 +1,133 @@
+package com.mufidgu.pastpapers.infrastructure.controller.instructor;
+
+import com.mufidgu.pastpapers.domain.instructor.Instructor;
+import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
+import com.mufidgu.pastpapers.domain.course.Course;
+import com.mufidgu.pastpapers.domain.course.spi.Courses;
+import com.mufidgu.pastpapers.domain.university.University;
+import com.mufidgu.pastpapers.domain.university.spi.Universities;
+import com.mufidgu.pastpapers.infrastructure.configuration.DomainConfiguration;
+import ddd.Stub;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+@Import(DomainConfiguration.class)
+public class InstructorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private Instructors instructors;
+
+    @Autowired
+    private Courses courses;
+
+    @Autowired
+    private Universities universities;
+
+    private Course testCourse;
+    private University testUniversity;
+
+    @BeforeEach
+    void setUp() {
+        // Create test course and university to use in instructor tests
+        testCourse = courses.save(new Course("AI", "Artificial Intelligence", List.of(), List.of()));
+        testUniversity = universities.save(new University("MIT", "Massachusetts Institute of Technology"));
+    }
+
+    @Test
+    void should_add_instructor() throws Exception {
+        mockMvc.perform(
+                post("/instructor/add")
+                        .contentType("application/json")
+                        .content(String.format("""
+                                {
+                                    "fullName": "John Doe",
+                                    "courseIds": ["%s"],
+                                    "universityIds": ["%s"]
+                                }
+                                """, testCourse.id(), testUniversity.id()))
+        )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andExpect(jsonPath("$.fullName").value("John Doe"))
+                .andExpect(jsonPath("$.courseIds[0]").value(testCourse.id().toString()))
+                .andExpect(jsonPath("$.universityIds[0]").value(testUniversity.id().toString()));
+    }
+
+    @Test
+    void should_return_all_instructors() throws Exception {
+        // Create a test instructor
+        instructors.save(new Instructor("Jane Smith", List.of(testCourse.id()), List.of(testUniversity.id())));
+
+        mockMvc.perform(
+                get("/instructor/all")
+                        .contentType("application/json")
+        )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isNotEmpty())
+                .andExpect(jsonPath("$[?(@.fullName == 'Jane Smith')]").exists());
+    }
+
+    @Test
+    void should_update_instructor() throws Exception {
+        // Create a test instructor
+        Instructor instructor = instructors.save(new Instructor("Robert Brown", List.of(testCourse.id()), List.of(testUniversity.id())));
+
+        mockMvc.perform(
+                put("/instructor/update?instructorId=" + instructor.id())
+                        .contentType("application/json")
+                        .content(String.format("""
+                                {
+                                    "fullName": "Robert Green",
+                                    "courseIds": ["%s"],
+                                    "universityIds": ["%s"]
+                                }
+                                """, testCourse.id(), testUniversity.id()))
+        )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(instructor.id().toString()))
+                .andExpect(jsonPath("$.fullName").value("Robert Green"))
+                .andExpect(jsonPath("$.courseIds[0]").value(testCourse.id().toString()))
+                .andExpect(jsonPath("$.universityIds[0]").value(testUniversity.id().toString()));
+    }
+
+    @Test
+    void should_delete_instructor() throws Exception {
+        // Create a test instructor
+        Instructor instructor = instructors.save(new Instructor("David Wilson", List.of(testCourse.id()), List.of(testUniversity.id())));
+
+        mockMvc.perform(
+                delete("/instructor/delete?instructorId=" + instructor.id())
+        )
+                .andExpect(status().isOk());
+
+        // Verify that the instructor is deleted
+        mockMvc.perform(get("/instructor/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.fullName == 'David Wilson')]").doesNotExist());
+    }
+
+    @TestConfiguration
+    @ComponentScan(
+            basePackageClasses = {Instructor.class, Course.class, University.class},
+            includeFilters = {@ComponentScan.Filter(type = FilterType.ANNOTATION, classes = {Stub.class})})
+    static class StubConfiguration {
+    }
+}


### PR DESCRIPTION
This pull request introduces a complete CRUD (Create, Read, Update, Delete) implementation for managing instructors in the application, including domain logic, API interfaces, persistence stubs, REST controller, and integration tests. The changes are grouped into domain model and logic, API interfaces, infrastructure/controller, persistence stub, and testing.

**Domain Model and Logic**

* Added the `Instructor` domain record to represent instructors, including their associated courses and universities.
* Implemented domain services for adding, updating, deleting, and fetching instructors, with validation for uniqueness and existence of related entities (`InstructorAdder`, `InstructorUpdater`, `InstructorDeleter`, `InstructorFetcher`).

**API Interfaces**

* Defined API interfaces for instructor operations: `AddInstructor`, `UpdateInstructor`, `DeleteInstructor`, and `FetchInstructor`, specifying the contract for each service.

**Infrastructure/Controller**

* Added `InstructorController` with REST endpoints for instructor CRUD operations, including request/response models and validation.

**Persistence Stub**

* Implemented `InMemoryInstructors` stub for instructor persistence, supporting all required operations for testing and development.

**Testing**

* Added `InstructorControllerTest` with integration tests to verify all instructor endpoints and their expected behaviors.

**Other**

* Minor cleanup in the `Courses` interface for consistency.…etch functionalities