### PR TITLE
feat: add initial README.md and Figma link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Past Papers Service
+This project is the web service required to run the Past Papers application. It is built using Spring Boot and aims to provide RESTful API for managing past papers.
+
+## Android Application Figma
+https://www.figma.com/design/KfHVSo1iniYjBlhp3ZTGVV/Past-Papers-v1?node-id=123-705&t=YAI4BeEBi5sHIeSA-1
+
+
+


### PR DESCRIPTION
This pull request adds initial documentation for the Past Papers Service project. The new `README.md` file provides an overview of the service and includes a link to the Android application's Figma design.

Project documentation:

* Added a `README.md` file describing the Past Papers Service, its purpose, and technology stack.
* Included a link to the Figma design for the Android application in the documentation.