### PR TITLE
refactor: use Lombok's @RequiredArgsConstructor for dependency injection

### DIFF
--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseAdder.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseAdder.java
@@ -5,22 +5,18 @@ import com.mufidgu.pastpapers.domain.course.spi.Courses;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class CourseAdder implements AddCourse {
 
     private final Courses courses;
     private final Degrees degrees;
     private final Universities universities;
-
-    public CourseAdder(Courses courses, Degrees degrees, Universities universities) {
-        this.courses = courses;
-        this.degrees = degrees;
-        this.universities = universities;
-    }
 
     public Course add(String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds) {
         // TODO: better error handling

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseDeleter.java
@@ -3,17 +3,15 @@ package com.mufidgu.pastpapers.domain.course;
 import com.mufidgu.pastpapers.domain.course.api.DeleteCourse;
 import com.mufidgu.pastpapers.domain.course.spi.Courses;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class CourseDeleter implements DeleteCourse {
 
     private final Courses courses;
-
-    public CourseDeleter(Courses courses) {
-        this.courses = courses;
-    }
 
     public void delete(UUID courseId) {
         courses.findById(courseId)

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseFetcher.java
@@ -3,17 +3,15 @@ package com.mufidgu.pastpapers.domain.course;
 import com.mufidgu.pastpapers.domain.course.api.FetchCourse;
 import com.mufidgu.pastpapers.domain.course.spi.Courses;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 @DomainService
+@RequiredArgsConstructor
 public class CourseFetcher implements FetchCourse {
 
     private final Courses courses;
-
-    public CourseFetcher(Courses courses) {
-        this.courses = courses;
-    }
 
     public List<Course> fetchAll() {
         return courses.findAll();

--- a/src/main/java/com/mufidgu/pastpapers/domain/course/CourseUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/course/CourseUpdater.java
@@ -5,22 +5,18 @@ import com.mufidgu.pastpapers.domain.course.spi.Courses;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class CourseUpdater implements UpdateCourse {
 
     private final Courses courses;
     private final Degrees degrees;
     private final Universities universities;
-
-    public CourseUpdater(Courses courses, Degrees degrees, Universities universities) {
-        this.courses = courses;
-        this.degrees = degrees;
-        this.universities = universities;
-    }
 
     public Course update(UUID id, String shortName, String fullName, List<UUID> degreeIds, List<UUID> universityIds) {
         // TODO: better error handling

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeAdder.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeAdder.java
@@ -4,20 +4,17 @@ import com.mufidgu.pastpapers.domain.degree.api.AddDegree;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class DegreeAdder implements AddDegree {
 
     private final Degrees degrees;
     private final Universities universities;
-
-    public DegreeAdder(Degrees degrees, Universities universities) {
-        this.degrees = degrees;
-        this.universities = universities;
-    }
 
     public Degree add(String shortName, String fullName, List<UUID> universities) {
         // TODO: better exception handling

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeDeleter.java
@@ -3,17 +3,15 @@ package com.mufidgu.pastpapers.domain.degree;
 import com.mufidgu.pastpapers.domain.degree.api.DeleteDegree;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class DegreeDeleter implements DeleteDegree {
 
     private final Degrees degrees;
-
-    public DegreeDeleter(Degrees degrees) {
-        this.degrees = degrees;
-    }
 
     public void delete(UUID id) {
         // TODO: better exception handling

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeFetcher.java
@@ -3,17 +3,15 @@ package com.mufidgu.pastpapers.domain.degree;
 import com.mufidgu.pastpapers.domain.degree.api.FetchDegree;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 @DomainService
+@RequiredArgsConstructor
 public class DegreeFetcher implements FetchDegree {
 
     private final Degrees degrees;
-
-    public DegreeFetcher(Degrees degrees) {
-        this.degrees = degrees;
-    }
 
     public List<Degree> fetchAll() {
         return degrees.findAll();

--- a/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/degree/DegreeUpdater.java
@@ -4,20 +4,17 @@ import com.mufidgu.pastpapers.domain.degree.api.UpdateDegree;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class DegreeUpdater implements UpdateDegree {
 
     private final Degrees degrees;
     private final Universities universities;
-
-    public DegreeUpdater(Degrees degrees, Universities universities) {
-        this.degrees = degrees;
-        this.universities = universities;
-    }
 
     public Degree update(UUID id, String shortName, String fullName, List<UUID> universities) {
         // TODO: better exception handling

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorAdder.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorAdder.java
@@ -5,22 +5,18 @@ import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
 import com.mufidgu.pastpapers.domain.course.spi.Courses;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class InstructorAdder implements AddInstructor {
 
     private final Instructors instructors;
     private final Courses courses;
     private final Universities universities;
-
-    public InstructorAdder(Instructors instructors, Courses courses, Universities universities) {
-        this.instructors = instructors;
-        this.courses = courses;
-        this.universities = universities;
-    }
 
     @Override
     public Instructor add(String fullName, List<UUID> courseIds, List<UUID> universityIds) {

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorDeleter.java
@@ -3,17 +3,15 @@ package com.mufidgu.pastpapers.domain.instructor;
 import com.mufidgu.pastpapers.domain.instructor.api.DeleteInstructor;
 import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class InstructorDeleter implements DeleteInstructor {
 
     private final Instructors instructors;
-
-    public InstructorDeleter(Instructors instructors) {
-        this.instructors = instructors;
-    }
 
     @Override
     public void delete(UUID instructorId) {

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorFetcher.java
@@ -3,17 +3,15 @@ package com.mufidgu.pastpapers.domain.instructor;
 import com.mufidgu.pastpapers.domain.instructor.api.FetchInstructor;
 import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 @DomainService
+@RequiredArgsConstructor
 public class InstructorFetcher implements FetchInstructor {
 
     private final Instructors instructors;
-
-    public InstructorFetcher(Instructors instructors) {
-        this.instructors = instructors;
-    }
 
     @Override
     public List<Instructor> fetchAll() {

--- a/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/instructor/InstructorUpdater.java
@@ -5,22 +5,18 @@ import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
 import com.mufidgu.pastpapers.domain.course.spi.Courses;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class InstructorUpdater implements UpdateInstructor {
 
     private final Instructors instructors;
     private final Courses courses;
     private final Universities universities;
-
-    public InstructorUpdater(Instructors instructors, Courses courses, Universities universities) {
-        this.instructors = instructors;
-        this.courses = courses;
-        this.universities = universities;
-    }
 
     @Override
     public Instructor update(UUID id, String fullName, List<UUID> courseIds, List<UUID> universityIds) {

--- a/src/main/java/com/mufidgu/pastpapers/domain/paper/PaperDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/paper/PaperDeleter.java
@@ -4,21 +4,18 @@ import com.mufidgu.pastpapers.domain.paper.api.DeletePaper;
 import com.mufidgu.pastpapers.domain.paper.spi.FileStorage;
 import com.mufidgu.pastpapers.domain.paper.spi.Papers;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.UUID;
 
 @Slf4j
 @DomainService
+@RequiredArgsConstructor
 public class PaperDeleter implements DeletePaper {
 
     private final Papers papers;
     private final FileStorage fileStorage;
-
-    public PaperDeleter(Papers papers, FileStorage fileStorage) {
-        this.papers = papers;
-        this.fileStorage = fileStorage;
-    }
 
     public void delete(UUID id) {
         Paper paper = papers.findById(id)

--- a/src/main/java/com/mufidgu/pastpapers/domain/paper/PaperDownloader.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/paper/PaperDownloader.java
@@ -4,20 +4,17 @@ import com.mufidgu.pastpapers.domain.paper.api.DownloadPaper;
 import com.mufidgu.pastpapers.domain.paper.spi.FileStorage;
 import com.mufidgu.pastpapers.domain.paper.spi.Papers;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class PaperDownloader implements DownloadPaper {
 
     private final Papers papers;
     private final FileStorage fileStorage;
-
-    public PaperDownloader(Papers papers, FileStorage fileStorage) {
-        this.papers = papers;
-        this.fileStorage = fileStorage;
-    }
 
     public File downloadPaper(UUID id) {
         Paper paper = papers.findById(id)

--- a/src/main/java/com/mufidgu/pastpapers/domain/paper/PaperLister.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/paper/PaperLister.java
@@ -3,17 +3,15 @@ package com.mufidgu.pastpapers.domain.paper;
 import com.mufidgu.pastpapers.domain.paper.api.ListPaper;
 import com.mufidgu.pastpapers.domain.paper.spi.Papers;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 @DomainService
+@RequiredArgsConstructor
 public class PaperLister implements ListPaper {
 
     private final Papers papers;
-
-    public PaperLister(Papers papers) {
-        this.papers = papers;
-    }
 
     public List<Paper> listAll() {
         return papers.findAll();

--- a/src/main/java/com/mufidgu/pastpapers/domain/paper/PaperUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/paper/PaperUpdater.java
@@ -6,18 +6,16 @@ import com.mufidgu.pastpapers.domain.paper.enums.Shift;
 import com.mufidgu.pastpapers.domain.paper.enums.Type;
 import com.mufidgu.pastpapers.domain.paper.spi.Papers;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.Date;
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class PaperUpdater implements UpdatePaper {
 
     private final Papers papers;
-
-    public PaperUpdater(Papers papers) {
-        this.papers = papers;
-    }
 
     public Paper update(
             UUID id,

--- a/src/main/java/com/mufidgu/pastpapers/domain/paper/PaperUploader.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/paper/PaperUploader.java
@@ -4,20 +4,17 @@ import com.mufidgu.pastpapers.domain.paper.api.UploadPaper;
 import com.mufidgu.pastpapers.domain.paper.spi.FileStorage;
 import com.mufidgu.pastpapers.domain.paper.spi.Papers;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.io.InputStream;
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class PaperUploader implements UploadPaper {
 
     private final Papers papers;
     private final FileStorage fileStorage;
-
-    public PaperUploader(Papers papers, FileStorage fileStorage) {
-        this.papers = papers;
-        this.fileStorage = fileStorage;
-    }
 
     public UUID uploadPaper(InputStream stream, String originalFilename) {
         try {

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityAdder.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityAdder.java
@@ -3,15 +3,13 @@ package com.mufidgu.pastpapers.domain.university;
 import com.mufidgu.pastpapers.domain.university.api.AddUniversity;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 @DomainService
+@RequiredArgsConstructor
 public class UniversityAdder implements AddUniversity {
 
     private final Universities universities;
-
-    public UniversityAdder(Universities universities) {
-        this.universities = universities;
-    }
 
     public University add(String shortName, String fullName) {
         universities.findByShortNameAndFullName(shortName, fullName).ifPresent(u -> {

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityDeleter.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityDeleter.java
@@ -3,17 +3,15 @@ package com.mufidgu.pastpapers.domain.university;
 import com.mufidgu.pastpapers.domain.university.api.DeleteUniversity;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class UniversityDeleter implements DeleteUniversity {
 
     private final Universities universities;
-
-    public UniversityDeleter(Universities universities) {
-        this.universities = universities;
-    }
 
     public void delete(UUID id) {
         universities.findById(id).orElseThrow(

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityFetcher.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityFetcher.java
@@ -3,17 +3,15 @@ package com.mufidgu.pastpapers.domain.university;
 import com.mufidgu.pastpapers.domain.university.api.FetchUniversity;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 @DomainService
+@RequiredArgsConstructor
 public class UniversityFetcher implements FetchUniversity {
 
     private final Universities universities;
-
-    public UniversityFetcher(Universities universities) {
-        this.universities = universities;
-    }
 
     public List<University> fetchAll() {
         return universities.findAll();

--- a/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityUpdater.java
+++ b/src/main/java/com/mufidgu/pastpapers/domain/university/UniversityUpdater.java
@@ -3,17 +3,15 @@ package com.mufidgu.pastpapers.domain.university;
 import com.mufidgu.pastpapers.domain.university.api.UpdateUniversity;
 import com.mufidgu.pastpapers.domain.university.spi.Universities;
 import ddd.DomainService;
+import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 
 @DomainService
+@RequiredArgsConstructor
 public class UniversityUpdater implements UpdateUniversity {
 
     private final Universities universities;
-
-    public UniversityUpdater(Universities universities) {
-        this.universities = universities;
-    }
 
     public University update(UUID id, String shortName, String fullName) {
         // TODO: better exception handling

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseController.java
@@ -7,6 +7,7 @@ import com.mufidgu.pastpapers.domain.course.api.FetchCourse;
 import com.mufidgu.pastpapers.domain.course.api.UpdateCourse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -16,6 +17,7 @@ import java.util.UUID;
 
 @Validated
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/course")
 public class CourseController {
 
@@ -23,17 +25,6 @@ public class CourseController {
     private final UpdateCourse courseUpdater;
     private final DeleteCourse courseDeleter;
     private final FetchCourse courseFetcher;
-
-    public CourseController(
-            AddCourse courseAdder,
-            UpdateCourse courseUpdater,
-            DeleteCourse courseDeleter,
-            FetchCourse courseFetcher) {
-        this.courseAdder = courseAdder;
-        this.courseUpdater = courseUpdater;
-        this.courseDeleter = courseDeleter;
-        this.courseFetcher = courseFetcher;
-    }
 
     // TODO: Admin Only
     // Validation, Already Exists, Degree/University Does Not Exist

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeController.java
@@ -7,6 +7,7 @@ import com.mufidgu.pastpapers.domain.degree.api.FetchDegree;
 import com.mufidgu.pastpapers.domain.degree.api.UpdateDegree;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -16,6 +17,7 @@ import java.util.UUID;
 
 @Validated
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/degree")
 public class DegreeController {
 
@@ -23,17 +25,6 @@ public class DegreeController {
     private final FetchDegree degreeFetcher;
     private final UpdateDegree degreeUpdater;
     private final DeleteDegree degreeDeleter;
-
-    public DegreeController(
-            AddDegree degreeAdder,
-            FetchDegree degreeFetcher,
-            UpdateDegree degreeUpdater,
-            DeleteDegree degreeDeleter) {
-        this.degreeAdder = degreeAdder;
-        this.degreeFetcher = degreeFetcher;
-        this.degreeUpdater = degreeUpdater;
-        this.degreeDeleter = degreeDeleter;
-    }
 
     // TODO: Admin only
     // Test cases validation, Already Exists, University Does Not Exist

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorController.java
@@ -7,6 +7,7 @@ import com.mufidgu.pastpapers.domain.instructor.api.FetchInstructor;
 import com.mufidgu.pastpapers.domain.instructor.api.UpdateInstructor;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -16,6 +17,7 @@ import java.util.UUID;
 
 @Validated
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/instructor")
 public class InstructorController {
 
@@ -23,17 +25,6 @@ public class InstructorController {
     private final UpdateInstructor instructorUpdater;
     private final DeleteInstructor instructorDeleter;
     private final FetchInstructor instructorFetcher;
-
-    public InstructorController(
-            AddInstructor instructorAdder,
-            UpdateInstructor instructorUpdater,
-            DeleteInstructor instructorDeleter,
-            FetchInstructor instructorFetcher) {
-        this.instructorAdder = instructorAdder;
-        this.instructorUpdater = instructorUpdater;
-        this.instructorDeleter = instructorDeleter;
-        this.instructorFetcher = instructorFetcher;
-    }
 
     // TODO: Admin Only
     @PostMapping("/add")

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/paper/PaperController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/paper/PaperController.java
@@ -6,6 +6,7 @@ import com.mufidgu.pastpapers.domain.paper.api.*;
 import com.mufidgu.pastpapers.infrastructure.annotation.FileTypeRestriction;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ import java.util.UUID;
 @Slf4j
 @Validated
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/paper")
 public class PaperController {
 
@@ -28,20 +30,6 @@ public class PaperController {
     private final UpdatePaper paperUpdater;
     private final DeletePaper paperDeleter;
     private final ListPaper paperLister;
-
-    public PaperController(
-            UploadPaper paperUploader,
-            DownloadPaper paperDownloader,
-            UpdatePaper paperUpdater,
-            DeletePaper paperDeleter,
-            ListPaper paperLister
-    ) {
-        this.paperUploader = paperUploader;
-        this.paperDownloader = paperDownloader;
-        this.paperUpdater = paperUpdater;
-        this.paperDeleter = paperDeleter;
-        this.paperLister = paperLister;
-    }
 
     @PostMapping("/upload")
     public ResponseEntity<String> addPaper(

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/university/UniversityController.java
@@ -6,6 +6,7 @@ import com.mufidgu.pastpapers.domain.university.api.FetchUniversity;
 import com.mufidgu.pastpapers.domain.university.api.UpdateUniversity;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -15,6 +16,7 @@ import java.util.UUID;
 
 @Validated
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/university")
 public class UniversityController {
 
@@ -22,17 +24,6 @@ public class UniversityController {
     private final FetchUniversity universityFetcher;
     private final UpdateUniversity universityUpdater;
     private final DeleteUniversity universityDeleter;
-
-    public UniversityController(
-            AddUniversity universityAdder,
-            FetchUniversity universityFetcher,
-            UpdateUniversity universityUpdater,
-            DeleteUniversity universityDeleter) {
-        this.universityAdder = universityAdder;
-        this.universityFetcher = universityFetcher;
-        this.universityUpdater = universityUpdater;
-        this.universityDeleter = universityDeleter;
-    }
 
     // TODO: Admin Only
     // Test Cases: Validation, Duplicate Short Name and Full Name,


### PR DESCRIPTION
This pull request refactors multiple domain service classes to use Lombok's `@RequiredArgsConstructor` annotation. By doing this, it removes the need for explicit constructor definitions, reducing boilerplate and making the codebase cleaner and easier to maintain. The changes are applied consistently across services.