### PR TITLE
implement resource server and basic security configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
     implementation("org.apache.tika:tika-core:3.2.2")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    testImplementation("org.springframework.security:spring-security-test")
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/configuration/SecurityConfiguration.java
@@ -1,0 +1,38 @@
+package com.mufidgu.pastpapers.infrastructure.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/course/add").hasRole("ADMIN")
+                        .requestMatchers("/course/update").hasRole("ADMIN")
+                        .requestMatchers("/course/delete").hasRole("ADMIN")
+                        .requestMatchers("/degree/add").hasRole("ADMIN")
+                        .requestMatchers("/degree/update").hasRole("ADMIN")
+                        .requestMatchers("/degree/delete").hasRole("ADMIN")
+                        .requestMatchers("/institution/add").hasRole("ADMIN")
+                        .requestMatchers("/institution/update").hasRole("ADMIN")
+                        .requestMatchers("/institution/delete").hasRole("ADMIN")
+                        .requestMatchers("/instructor/add").hasRole("ADMIN")
+                        .requestMatchers("/instructor/update").hasRole("ADMIN")
+                        .requestMatchers("/instructor/delete").hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(
+                        oauth2 -> oauth2.jwt(Customizer.withDefaults())
+                );
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseController.java
@@ -27,7 +27,6 @@ public class CourseController {
     private final DeleteCourse courseDeleter;
     private final ListCourse courseLister;
 
-    // TODO: Admin Only
     // Validation, Already Exists, Degree/Institution Does Not Exist
     @PostMapping("/add")
     public ResponseEntity<CourseResource> add(@Valid @RequestBody CourseRequest request) {
@@ -46,7 +45,6 @@ public class CourseController {
         ));
     }
 
-    // TODO: Admin Only
     @PutMapping("/update")
     public ResponseEntity<CourseResource> update(
             @NotBlank @RequestParam String courseId,
@@ -69,7 +67,6 @@ public class CourseController {
         ));
     }
 
-    // TODO: Admin Only
     @DeleteMapping("/delete")
     public ResponseEntity<Void> delete(@NotBlank @RequestParam String courseId) {
         UUID id = UUID.fromString(courseId);
@@ -77,17 +74,16 @@ public class CourseController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    // TODO: Registered Users Only
     @GetMapping("/list")
     public ResponseEntity<Iterable<CourseResource>> list() {
         List<Course> courses = courseLister.listAll();
         return ResponseEntity.ok(courses.stream()
-                .map(c -> new CourseResource(
-                        c.id(),
-                        c.shortName(),
-                        c.fullName(),
-                        c.degreeIds(),
-                        c.institutionIds()))
+                .map(it -> new CourseResource(
+                        it.id(),
+                        it.shortName(),
+                        it.fullName(),
+                        it.degreeIds(),
+                        it.institutionIds()))
                 .toList());
     }
 

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeController.java
@@ -27,7 +27,6 @@ public class DegreeController {
     private final UpdateDegree degreeUpdater;
     private final DeleteDegree degreeDeleter;
 
-    // TODO: Admin only
     // Test cases validation, Already Exists, Institution Does Not Exist
     @PostMapping("/add")
     public ResponseEntity<DegreeResource> add(@Valid @RequestBody DegreeRequest request) {
@@ -40,7 +39,6 @@ public class DegreeController {
         ));
     }
 
-    // TODO: Admin only
     // Test cases validation, Degree/Institution Does Not Exist
     @PostMapping("/update")
     public ResponseEntity<DegreeResource> update(
@@ -62,7 +60,6 @@ public class DegreeController {
         ));
     }
 
-    // TODO: Admin only
     // Test cases validation, Degree Does Not Exist
     @PostMapping("/delete")
     public ResponseEntity<Void> delete(@RequestParam @NotBlank String degreeId) {
@@ -71,12 +68,11 @@ public class DegreeController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    // TODO: Registered users only
     @GetMapping("/list")
     public ResponseEntity<Iterable<DegreeResource>> list() {
         List<Degree> degrees = degreeLister.listAll();
         return ResponseEntity.ok(degrees.stream()
-                .map(d -> new DegreeResource(d.id(), d.shortName(), d.fullName(), d.institutions()))
+                .map(it -> new DegreeResource(it.id(), it.shortName(), it.fullName(), it.institutions()))
                 .toList());
     }
 }

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/institution/InstitutionController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/institution/InstitutionController.java
@@ -27,7 +27,6 @@ public class InstitutionController {
     private final UpdateInstitution institutionUpdater;
     private final DeleteInstitution institutionDeleter;
 
-    // TODO: Admin Only
     // Test Cases: Validation, Duplicate Short Name and Full Name,
     @PostMapping("/add")
     public ResponseEntity<InstitutionResource> add(@Valid @RequestBody InstitutionRequest request) {
@@ -39,7 +38,6 @@ public class InstitutionController {
         ));
     }
 
-    // TODO: Registered Users Only
     @GetMapping("/list")
     public ResponseEntity<Iterable<InstitutionResource>> list() {
         List<Institution> institutions = institutionLister.listAll();
@@ -48,7 +46,6 @@ public class InstitutionController {
                 .toList());
     }
 
-    // TODO: Admin Only
     // Test Cases: Validation, Duplicate Short Name and Full Name,
     @PutMapping("/update")
     public ResponseEntity<InstitutionResource> update(
@@ -64,7 +61,6 @@ public class InstitutionController {
         ));
     }
 
-    // TODO: Admin Only
     // Test Cases: Validation, Institution Not Found
     @DeleteMapping("/delete")
     public ResponseEntity<Void> delete(@RequestParam @NotBlank String institutionId) {

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorController.java
@@ -27,7 +27,6 @@ public class InstructorController {
     private final DeleteInstructor instructorDeleter;
     private final ListInstructor instructorLister;
 
-    // TODO: Admin Only
     @PostMapping("/add")
     public ResponseEntity<InstructorResource> add(@Valid @RequestBody InstructorRequest request) {
         Instructor instructor = instructorAdder.add(
@@ -43,7 +42,6 @@ public class InstructorController {
         ));
     }
 
-    // TODO: Admin Only
     @PutMapping("/update")
     public ResponseEntity<InstructorResource> update(
             @NotBlank @RequestParam String instructorId,
@@ -64,7 +62,6 @@ public class InstructorController {
         ));
     }
 
-    // TODO: Admin Only
     @DeleteMapping("/delete")
     public ResponseEntity<Void> delete(@NotBlank @RequestParam String instructorId) {
         UUID id = UUID.fromString(instructorId);
@@ -72,16 +69,15 @@ public class InstructorController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    // TODO: Registered Users Only
     @GetMapping("/list")
     public ResponseEntity<Iterable<InstructorResource>> list() {
         List<Instructor> instructors = instructorLister.listAll();
         return ResponseEntity.ok(instructors.stream()
-                .map(i -> new InstructorResource(
-                        i.id(),
-                        i.fullName(),
-                        i.courseIds(),
-                        i.institutionIds()))
+                .map(it -> new InstructorResource(
+                        it.id(),
+                        it.fullName(),
+                        it.courseIds(),
+                        it.institutionIds()))
                 .toList());
     }
 }

--- a/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/paper/PaperController.java
+++ b/src/main/java/com/mufidgu/pastpapers/infrastructure/controller/paper/PaperController.java
@@ -118,19 +118,19 @@ public class PaperController {
     public ResponseEntity<List<PaperResource>> list() {
         List<Paper> papers = paperLister.listAll();
         List<PaperResource> paperResources = papers.stream()
-                .map(paper -> new PaperResource(
-                        paper.id(),
-                        paper.instructorId(),
-                        paper.courseId(),
-                        paper.type(),
-                        paper.institutionId(),
-                        paper.degreeId(),
-                        paper.shift(),
-                        paper.semester(),
-                        paper.section(),
-                        paper.year(),
-                        paper.season(),
-                        paper.date()
+                .map(it -> new PaperResource(
+                        it.id(),
+                        it.instructorId(),
+                        it.courseId(),
+                        it.type(),
+                        it.institutionId(),
+                        it.degreeId(),
+                        it.shift(),
+                        it.semester(),
+                        it.section(),
+                        it.year(),
+                        it.season(),
+                        it.date()
                 )).toList();
         return ResponseEntity.ok(paperResources);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,9 @@
 spring.application.name=pastpapers-service
+
 spring.mvc.problemdetails.enabled=true
+
 spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=100MB
+
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://accounts.google.com

--- a/src/test/java/com/mufidgu/pastpapers/ApplicationTests.java
+++ b/src/test/java/com/mufidgu/pastpapers/ApplicationTests.java
@@ -1,13 +1,77 @@
 package com.mufidgu.pastpapers;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mufidgu.pastpapers.infrastructure.controller.institution.InstitutionRequest;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class ApplicationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     void contextLoads() {
     }
 
+    @Test
+    void whenNotAuthenticated_thenUnauthorized() throws Exception {
+        mockMvc.perform(get("/paper/list"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void whenJwtAuthenticated_thenOk() throws Exception {
+        mockMvc.perform(get("/paper/list")
+                        .with(jwt()
+                                .jwt(jwt -> {
+                                    jwt.claim("sub", "1234567890");
+                                    jwt.claim("email", "user@example.com");
+                                    jwt.claim("scope", "paper.read");
+                                })))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void whenAdminRole_thenCanAddInstitution() throws Exception {
+        InstitutionRequest req = new InstitutionRequest();
+
+        req.shortName = "MIT";
+        req.fullName = "Massachusetts Institute of Technology";
+
+        mockMvc.perform(post("/institution/add")
+                        .with(jwt().authorities(AuthorityUtils.createAuthorityList("ROLE_ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void whenNotAdminRole_thenForbidden() throws Exception {
+        InstitutionRequest req = new InstitutionRequest();
+
+        req.shortName = "MIT";
+        req.fullName = "Massachusetts Institute of Technology";
+
+        mockMvc.perform(post("/institution/add")
+                        .with(jwt().authorities(AuthorityUtils.createAuthorityList("ROLE_USER")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden());
+    }
 }

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/course/CourseControllerTest.java
@@ -11,6 +11,7 @@ import ddd.Stub;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
@@ -26,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest
 @Import(DomainConfiguration.class)
+@AutoConfigureMockMvc(addFilters = false)
 public class CourseControllerTest {
 
     @Autowired

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/degree/DegreeControllerTest.java
@@ -9,6 +9,7 @@ import ddd.Stub;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest
 @Import(DomainConfiguration.class)
+@AutoConfigureMockMvc(addFilters = false)
 public class DegreeControllerTest {
 
     @Autowired

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/institution/InstitutionControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/institution/InstitutionControllerTest.java
@@ -6,6 +6,7 @@ import com.mufidgu.pastpapers.infrastructure.configuration.DomainConfiguration;
 import ddd.Stub;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest
 @Import(DomainConfiguration.class)
+@AutoConfigureMockMvc(addFilters = false)
 public class InstitutionControllerTest {
 
     @Autowired

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/instructor/InstructorControllerTest.java
@@ -1,16 +1,17 @@
 package com.mufidgu.pastpapers.infrastructure.controller.instructor;
 
-import com.mufidgu.pastpapers.domain.instructor.Instructor;
-import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
 import com.mufidgu.pastpapers.domain.course.Course;
 import com.mufidgu.pastpapers.domain.course.spi.Courses;
 import com.mufidgu.pastpapers.domain.institution.Institution;
 import com.mufidgu.pastpapers.domain.institution.spi.Institutions;
+import com.mufidgu.pastpapers.domain.instructor.Instructor;
+import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
 import com.mufidgu.pastpapers.infrastructure.configuration.DomainConfiguration;
 import ddd.Stub;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
@@ -26,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest
 @Import(DomainConfiguration.class)
+@AutoConfigureMockMvc(addFilters = false)
 public class InstructorControllerTest {
 
     @Autowired

--- a/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/paper/PaperControllerTest.java
+++ b/src/test/java/com/mufidgu/pastpapers/infrastructure/controller/paper/PaperControllerTest.java
@@ -4,6 +4,8 @@ import com.mufidgu.pastpapers.domain.course.Course;
 import com.mufidgu.pastpapers.domain.course.spi.Courses;
 import com.mufidgu.pastpapers.domain.degree.Degree;
 import com.mufidgu.pastpapers.domain.degree.spi.Degrees;
+import com.mufidgu.pastpapers.domain.institution.Institution;
+import com.mufidgu.pastpapers.domain.institution.spi.Institutions;
 import com.mufidgu.pastpapers.domain.instructor.Instructor;
 import com.mufidgu.pastpapers.domain.instructor.spi.Instructors;
 import com.mufidgu.pastpapers.domain.paper.Paper;
@@ -12,13 +14,12 @@ import com.mufidgu.pastpapers.domain.paper.enums.Shift;
 import com.mufidgu.pastpapers.domain.paper.enums.Type;
 import com.mufidgu.pastpapers.domain.paper.spi.FileStorage;
 import com.mufidgu.pastpapers.domain.paper.spi.Papers;
-import com.mufidgu.pastpapers.domain.institution.Institution;
-import com.mufidgu.pastpapers.domain.institution.spi.Institutions;
 import com.mufidgu.pastpapers.infrastructure.configuration.DomainConfiguration;
 import ddd.Stub;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
@@ -40,6 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest
 @Import(DomainConfiguration.class)
+@AutoConfigureMockMvc(addFilters = false)
 public class PaperControllerTest {
 
     @Autowired


### PR DESCRIPTION
This pull request introduces role-based security to the application using Spring Security, specifically enforcing that only users with the "ADMIN" role can perform sensitive actions (add, update, delete) on core entities. It also configures JWT-based authentication using Google as the issuer and adds integration tests to verify the new security behavior. Minor refactoring was done to streamline mapping code and test configurations.

**Security and Authorization**

* Added a new `SecurityConfiguration` class to enforce role-based access control using Spring Security. Only users with the "ADMIN" role can access add, update, and delete endpoints for `course`, `degree`, `institution`, and `instructor` resources; all other endpoints require authentication. Configured JWT-based OAuth2 resource server with Google as the issuer.
* Removed obsolete `// TODO: Admin Only` and `// TODO: Registered Users Only` comments from controller classes, as security is now enforced via configuration. 

**Testing and Validation**

* Added integration tests in `ApplicationTests` to verify authentication and authorization: unauthenticated requests are rejected, authenticated users can access list endpoints, only admins can add institutions, and non-admins are forbidden.
* Updated controller test classes to disable security filters for unit testing by adding `@AutoConfigureMockMvc(addFilters = false)`.

**Code Quality and Refactoring**

* Updated mapping code in several controllers to use more descriptive variable names (`it` instead of `c`, `d`, `i`, etc.) for consistency and clarity.

**Configuration**

* Updated `application.properties` to enable JWT authentication with Google as the issuer and made minor property additions for multipart file handling.